### PR TITLE
only show brain benchmarks level 1, collapse engineering root

### DIFF
--- a/benchmarks/templates/benchmarks/table.html
+++ b/benchmarks/templates/benchmarks/table.html
@@ -38,7 +38,8 @@
                     {% if benchmark.identifier in uniform_parents %}
                         <strong data-benchmark="{{ benchmark.short_name }}" style="font-size: 10px"
                                 class="
-                            {% if benchmark.depth == BASE_DEPTH %}
+                            {# show brain benchmarks up to the base depth #}
+                            {% if benchmark.root_parent == 'engineering' or benchmark.depth == BASE_DEPTH %}
                                 headerExpand
                             {% else %}
                                 headerContract

--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -59,7 +59,10 @@ def get_context(user=None):
     # configure benchmark level shown by default
     uniform_parents = set(
         benchmark_parents.values())  # we're going to use the fact that all benchmark instances currently point to their direct parent
-    not_shown_set = {benchmark.identifier for benchmark in benchmarks if benchmark.depth > BASE_DEPTH}
+    not_shown_set = {benchmark.identifier for benchmark in benchmarks
+                     if benchmark.depth > BASE_DEPTH or
+                     # show engineering benchmarks collapsed, but still show root
+                     (benchmark.short_name != ENGINEERING_ROOT and benchmark.root_parent == ENGINEERING_ROOT)}
 
     # data for javascript comparison script
     comparison_data = _build_comparison_data(model_rows)
@@ -167,7 +170,7 @@ def _collect_models(benchmarks, user=None):
                     # many engineering benchmarks (e.g. ImageNet) don't have a notion of a primate ceiling.
                     # instead, we display the raw score if there is no ceiled score.
                     benchmark_id = f'{score.benchmark.benchmark_type.identifier}_v{score.benchmark.version}'
-                    if benchmark_lookup[benchmark_id].root_parent != 'engineering' \
+                    if benchmark_lookup[benchmark_id].root_parent != ENGINEERING_ROOT \
                             or score.score_ceiled is not None:
                         score_ceiled = score.score_ceiled
                     else:


### PR DESCRIPTION
not sure if this is a good idea, I'm worried it will give the impression that engineering is factored into the average (#42 might make them look even more similar).
![image](https://user-images.githubusercontent.com/5308236/95255878-060d1c00-07f0-11eb-8c69-3f013e740d05.png)
