### PR TITLE
set file log level to INFO if not debugging

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -196,6 +196,7 @@ COMPRESS_PRECOMPILERS = (
 AUTH_USER_MODEL = 'benchmarks.User'
 
 # Logging
+log_level = 'DEBUG' if DEBUG else 'INFO'
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -204,7 +205,7 @@ LOGGING = {
             'class': 'logging.StreamHandler',
         },
         'file': {
-            'level': 'DEBUG',
+            'level': log_level,
             'class': 'logging.FileHandler',
             'filename': os.path.join(BASE_DIR, 'django.log'),
         },

--- a/web/settings.py
+++ b/web/settings.py
@@ -213,7 +213,7 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['file', 'console'],
-            'level': 'DEBUG',
+            'level': log_level,
             'propagate': True,
         },
     },


### PR DESCRIPTION
This is partly to address log errors we have been seeing like `KeyError: 'Incorrect'` (from [user.py](https://github.com/brain-score/brain-score.web/blob/6c67fbbbf8169b20b0130e1216fd1c9377bac820/benchmarks/views/user.py#L96) and [login.html](https://github.com/brain-score/brain-score.web/blob/6c67fbbbf8169b20b0130e1216fd1c9377bac820/benchmarks/templates/benchmarks/login.html#L31)) where the template checked for the variable with an `{% if %}` -- even though django [documentation states](https://docs.djangoproject.com/en/dev/ref/templates/builtins/#if) that it will also test for variable existence, it [apparently](https://github.com/golemfactory/concent/issues/626#issuecomment-404571208) still logs a DEBUG warning.