### PR TITLE
catch all formatting errors for `format_score`

### DIFF
--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -514,5 +514,5 @@ def get_parent_item(dictionary, key):
 def format_score(score):
     try:
         return f"{score:.3f}"
-    except ValueError:  # e.g. 'X'
+    except:  # e.g. 'X'
         return score


### PR DESCRIPTION
otherwise nan/null scores will fail with
```
  File "/app/benchmarks/views/index.py", line 516, in format_score
    return f"{score:.3f}"
TypeError: unsupported format string passed to NoneType.__format__
```