### PR TITLE
display empty space instead of 'None' when display name is not set

### DIFF
--- a/benchmarks/templates/benchmarks/table.html
+++ b/benchmarks/templates/benchmarks/table.html
@@ -104,7 +104,7 @@
                         </a>
                     </div>
                     <div class="submitter">
-                        {{ model|display_submitter:user }}
+                        {{ model|display_submitter:user|default:"&nbsp;" }}
                     </div>
 
                     {% if not model.primary_model_id and model.num_secondary_models %}


### PR DESCRIPTION
before:
![before2](https://user-images.githubusercontent.com/5308236/151665966-d064e768-1fd7-425b-8cf7-6c81dac8222f.PNG)
![before](https://user-images.githubusercontent.com/5308236/151665968-3055562d-2d87-4fba-abfd-2c1aec194513.PNG)

after:
![after2](https://user-images.githubusercontent.com/5308236/151665970-3446934d-b3b7-4b77-9bf2-5ad0e15e2470.PNG)
![after](https://user-images.githubusercontent.com/5308236/151665971-a0f280e4-f6f1-4114-bee7-f3f87099a12e.PNG)

