### PR TITLE
compute rank based on all public models

### DIFF
--- a/benchmarks/templates/benchmarks/model.html
+++ b/benchmarks/templates/benchmarks/model.html
@@ -77,7 +77,7 @@
     {# Benchmark scores #}
     <h2 id="scores" class="title-is-2">Benchmark scores</h2>
     <span class='fine_print'>
-       Model rank shown below is with respect to the main site (all submissions), not just the competition. <br>
+       Model rank shown below is with respect to all public models.<br>
     </span>
     <div class="benchmark_scores">
         {% for score_row in model.scores %}

--- a/benchmarks/views/model.py
+++ b/benchmarks/views/model.py
@@ -59,7 +59,9 @@ def contextualize_scores(model, reference_context):
         other_scores = [other_score.score_ceiled
                         for other_model in reference_context['models']
                         for other_score in other_model.scores
-                        if other_score.versioned_benchmark_identifier == score.versioned_benchmark_identifier]
+                        if other_model.public
+                        and other_score.versioned_benchmark_identifier == score.versioned_benchmark_identifier
+                        ]
         other_scores = [simplify_score(other_score) for other_score in other_scores]
         # per-score ranks
         if score.score_ceiled == 'X' or score.score_ceiled == '':


### PR DESCRIPTION
in other words, exclude private models from rank comparison.

before (notice how the rank is larger than the number of models that are publicly shown on the main leaderboard):
![before](https://user-images.githubusercontent.com/5308236/206919893-40340c57-49df-44da-98f9-751a7b2e7fbc.PNG)

after:
![after](https://user-images.githubusercontent.com/5308236/206920006-7b4e8cba-5d9f-491a-ad33-0413e9385ddb.PNG)

resolve #155 @patrickmineault