### PR TITLE
Hotfix: default /profile link broken

### DIFF
--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -13,6 +13,9 @@ urlpatterns = [
     path('public-ajax/', user.PublicAjax.as_view(), name='PublicAjax'),
     path('competition/', competition.view, name='competition'),
 
+    # default profile is vision
+    path('profile/', user.Profile.as_view(domain="vision"), name='default-profile'),
+
     # language changes
     path('vision/', functools.partial(index, domain='vision'), name='index'),
     path('language/', functools.partial(index, domain='language'), name='index'),


### PR DESCRIPTION
This PR sets the default URL for /profile to vision (in keeping with the other defaults for the site)