### PR TITLE
Language resubmission job name/URL is fixed

### DIFF
--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -332,7 +332,7 @@ def resubmit(request):
     if len(model_ids) == 0 or len(benchmarks) == 0:
         return render(request, 'benchmarks/submission_error.html', {'error': "No model ids and benchmarks found"})
 
-    for model_id in model_id_name_dict.keys():
+    for model_id, model_name in model_id_name_dict.items():
         json_info = {
             "domain": domain,
             "user_id": request.user.id,
@@ -340,7 +340,7 @@ def resubmit(request):
         }
         with open('result.json', 'w') as fp:
             json.dump(json_info, fp)
-        submit_to_jenkins(request, domain, model_id_name_dict[model_id], benchmarks)
+        submit_to_jenkins(request, domain, model_name, benchmarks)
     return render(request, 'benchmarks/success.html')
 
 


### PR DESCRIPTION
This PR:

1. Assigns the `score_plugin` job to language resubmissions
2. Builds a new language resubmission URL in line with `score_plugin's` parameter specifications