### PR TITLE
AWS fixes; Allow new env to be hosted properly

### DIFF
--- a/.ebextensions/03_immutable.config
+++ b/.ebextensions/03_immutable.config
@@ -3,3 +3,6 @@ option_settings:
     RollingUpdateType: Immutable
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
+  aws:autoscaling:launchconfiguration:
+    BlockDeviceMappings: /dev/xvdcz=:48:true:gp2
+    RootVolumeSize: 48

--- a/environment.yml
+++ b/environment.yml
@@ -16,5 +16,4 @@ dependencies:
     - django_compressor
     - colour
     - tqdm
-    - awsebcli
     - requests

--- a/web/settings.py
+++ b/web/settings.py
@@ -119,7 +119,7 @@ def get_db_info():
         DATABASES = {
             'default': {
                 'ENGINE': 'django.db.backends.postgresql_psycopg2',
-                'NAME': "dev",
+                'NAME': secrets["dbInstanceIdentifier"],
                 'USER': secrets["username"],
                 'PASSWORD': secrets["password"],
                 'HOST': secrets["host"],
@@ -131,7 +131,7 @@ def get_db_info():
             DATABASES = {
                 'default': {
                     'ENGINE': 'django.db.backends.postgresql_psycopg2',
-                    'NAME': "dev",
+                    'NAME': os.environ['RDS_DB_NAME'],
                     'USER': os.environ['RDS_USERNAME'],
                     'PASSWORD': os.environ['RDS_PASSWORD'],
                     'HOST': os.environ['RDS_HOSTNAME'],

--- a/web/settings.py
+++ b/web/settings.py
@@ -45,7 +45,9 @@ except NoCredentialsError:
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False") == "True"
 
-ALLOWED_HOSTS = os.getenv("DOMAIN", "localhost:brain-score-web-dev.us-east-2.elasticbeanstalk.com").split(":")
+ALLOWED_HOSTS = [os.getenv("DOMAIN", "localhost:brain-score-web-dev.us-east-2.elasticbeanstalk.com").split(":"),
+                 os.getenv("DOMAIN", "localhost:Brain-score-web-prod-updated.kmk2mcntkw.us-east-2.elasticbeanstalk.com").split(":")]
+
 
 # Allows E-mail use
 # After 6/1/22, Google removed login with username/password from "less secure apps" (i.e. Django)
@@ -117,7 +119,7 @@ def get_db_info():
         DATABASES = {
             'default': {
                 'ENGINE': 'django.db.backends.postgresql_psycopg2',
-                'NAME': secrets["dbInstanceIdentifier"],
+                'NAME': "dev",
                 'USER': secrets["username"],
                 'PASSWORD': secrets["password"],
                 'HOST': secrets["host"],
@@ -129,7 +131,7 @@ def get_db_info():
             DATABASES = {
                 'default': {
                     'ENGINE': 'django.db.backends.postgresql_psycopg2',
-                    'NAME': os.environ['RDS_DB_NAME'],
+                    'NAME': "dev",
                     'USER': os.environ['RDS_USERNAME'],
                     'PASSWORD': os.environ['RDS_PASSWORD'],
                     'HOST': os.environ['RDS_HOSTNAME'],


### PR DESCRIPTION
Following the site being down the week of 7/18, these AWS fixes brought it back up:

1. Deleted awscli from environment.yml, as per [this](https://stackoverflow.com/questions/76708329/docker-compose-no-longer-building-image-attributeerror-cython-sources) issue
2. Updated the config to use 48 GB of AWS space instead of the previous 12GB, so we do not run out of space anymore when building the docker container. 
3. Added the updated prod environment URL to allowed hosts 