### PR TITLE
Force HTTPS

### DIFF
--- a/.ebextensions/03_https_redirect.config
+++ b/.ebextensions/03_https_redirect.config
@@ -1,0 +1,17 @@
+Resources:
+ AWSEBV2LoadBalancerListener:
+  Type: AWS::ElasticLoadBalancingV2::Listener
+  Properties:
+    LoadBalancerArn:
+      Ref: AWSEBV2LoadBalancer
+    Port: 80
+    Protocol: HTTP
+    DefaultActions:
+      - Type: redirect
+        RedirectConfig:
+          Host: "#{host}"
+          Path: "/#{path}"
+          Port: "443"
+          Protocol: "HTTPS"
+          Query: "#{query}"
+          StatusCode: "HTTP_301"


### PR DESCRIPTION
Configure EB Application Load Balancer to force HTTP -> HTTPS redirects.

Note: this should also resolve the issue of CSRF errors when attempting to login over HTTP. 
<img width="566" alt="image" src="https://github.com/brain-score/brain-score.web/assets/14812599/d78684f5-bb59-4942-b113-5023d63c139f">
