### PR TITLE
Displaying benchmark identifier instead of short name on website

### DIFF
--- a/benchmarks/templates/benchmarks/competition.html
+++ b/benchmarks/templates/benchmarks/competition.html
@@ -220,7 +220,7 @@
             {% for stimulus_sample in stimuli_samples %}
                 <img class="stimulus_sample"
                      src="/static/benchmarks/img/benchmark_samples/{{ stimulus_sample.path }}"
-                     title="from benchmark {{ stimulus_sample.benchmark_short_name }}"
+                     title="from benchmark {{ stimulus_sample.benchmark_identifier }}"
                      alt="sample {{ stimulus_sample.path }}"/>
             {% endfor %}
         </div>

--- a/benchmarks/templates/benchmarks/submissions.html
+++ b/benchmarks/templates/benchmarks/submissions.html
@@ -8,7 +8,7 @@
         <div class="columns">
             <div class="column is-half">
                 <h4>Pick benchmarks</h4>
-                {% for short_name, benchmark_type_id in submittable_benchmarks.items %}
+                {% for identifier, benchmark_type_id in submittable_benchmarks.items %}
                 <div id=benchmarkGroup" class="field">
                     <input class="checkbox is-checkradio is-block benchmark_checker" type="checkbox"
                            onclick="enableButtonBench()"
@@ -17,7 +17,7 @@
                            value="{{ benchmark_type_id }}"
                            id="benchmark-{{ benchmark_type_id }}">
                     <label class="checkbox" for="benchmark-{{ benchmark_type_id }}">
-                        {{ short_name }}
+                        {{ identifier }}
                     </label>
                 </div>
                 {% endfor %}

--- a/benchmarks/tests/test_views.py
+++ b/benchmarks/tests/test_views.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from benchmarks.views.index import _get_benchmark_shortname
 from benchmarks.views.user import split_identifier_version
 
 ALL_FIXTURES = ['fixture-benchmarkreferences.json', 'fixture-benchmarktypes.json',
@@ -97,3 +98,31 @@ class TestLanguage(TestCase):
         content = resp.content.decode('utf-8')
         num_rows = content.count("<tr")
         self.assertEqual(num_rows, 9)
+
+
+class TestBenchmarkShortname:
+    fixtures = ALL_FIXTURES
+
+    def test_no_lab_id(self):
+        benchmark_identifier = "Kar2019-ost"
+        shortname = _get_benchmark_shortname(benchmark_identifier)
+        expected_shortname = "Kar2019-ost"
+        self.assertEqual(shortname, expected_shortname)
+
+    def test_lab_id(self):
+        benchmark_identifier = "fei-fei.Deng2009-top1"
+        shortname = _get_benchmark_shortname(benchmark_identifier)
+        expected_shortname = "Deng2009-top1"
+        self.assertEqual(shortname, expected_shortname)
+
+    def test_no_lab_id_with_version(self):
+        benchmark_identifier = "MajajHong2015.V4-pls"
+        shortname = _get_benchmark_shortname(benchmark_identifier)
+        expected_shortname = "MajajHong2015.V4-pls"
+        self.assertEqual(shortname, expected_shortname)
+
+    def test_lab_id_with_version(self):
+        benchmark_identifier = "dicarlo.MajajHong2015.V4-pls"
+        shortname = _get_benchmark_shortname(benchmark_identifier)
+        expected_shortname = "MajajHong2015.V4-pls"
+        self.assertEqual(shortname, expected_shortname)

--- a/benchmarks/views/competition.py
+++ b/benchmarks/views/competition.py
@@ -117,7 +117,7 @@ def create_stimuli_samples(benchmark_instances, num_samples, available_sample_pe
     :param available_sample_per_benchmark: how many image files have been pre-generated per benchmark
     :return:
     """
-    StimulusSample = namedtuple('StimulusSample', field_names=['path', 'benchmark_short_name'])
+    StimulusSample = namedtuple('StimulusSample', field_names=['path', 'benchmark_identifier'])
 
     samples = set()
     random = RandomState(42)
@@ -125,7 +125,7 @@ def create_stimuli_samples(benchmark_instances, num_samples, available_sample_pe
         benchmark = random.choice(benchmark_instances)
         sample_num = random.randint(low=0, high=available_sample_per_benchmark)
         path = f"{benchmark.identifier}/{sample_num}.png"
-        sample = StimulusSample(path=path, benchmark_short_name=benchmark.identifier)
+        sample = StimulusSample(path=path, benchmark_identifier=benchmark.identifier)
         samples.add(sample)
     samples = list(sorted(samples))  # make order deterministic
     random.shuffle(samples)  # reshuffle


### PR DESCRIPTION
Currently, for benchmarks with a lab identifier (e.g. `dicarlo.MajajHong2015.V4-pls`), a [benchmark short name is derived](https://github.com/brain-score/brain-score.web/blob/master/benchmarks/views/index.py#L210) by removing the lab identifier.

Since lab identifiers have been removed from benchmark identifiers in the database, the short name derivation now eliminates a part of the benchmark identifier instead (e.g. `MajajHong2015.V4-pls` -> `V4-pls`), causing display problems on the website (as highlighted in red below):
<img width="1063" alt="Screenshot 2024-01-29 at 4 16 25 PM" src="https://github.com/brain-score/brain-score.web/assets/45083797/0ea51fff-6a6e-43b9-b21d-4e1dcb670604">

This PR fixes this by displaying the full benchmark identifier instead of the short name.