### PR TITLE
Removed public/private submissions and brain/base models for vision

### DIFF
--- a/benchmarks/forms.py
+++ b/benchmarks/forms.py
@@ -36,19 +36,6 @@ class UploadPlaceHolder(forms.Form):
 
 
 class UploadFileForm(forms.Form):
-    model_type = forms.ChoiceField(choices=[
-        ("BaseModel", "Base model - to submit a standard machine learning model"),
-        ("BrainModel", "Brain model - to change brain-transformation")])
-    zip_file = forms.FileField(label="", help_text='Required')
-    public = forms.BooleanField(label='Make model scores public (can be changed later):', required=False,
-                                help_text='Check if you want the results of your submitted models included in the public ranking.')
-
-    class Meta:
-        model = UploadPlaceHolder
-        fields = ('zip_file', 'public', 'competition')
-
-
-class UploadFileFormLanguage(forms.Form):
     zip_file = forms.FileField(label="", help_text='Required')
 
     class Meta:

--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -18,7 +18,7 @@ from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.views import View
 
-from benchmarks.forms import SignupForm, LoginForm, UploadFileForm, UploadFileFormLanguage
+from benchmarks.forms import SignupForm, LoginForm, UploadFileForm
 from benchmarks.models import Model, BenchmarkInstance, BenchmarkType
 from benchmarks.tokens import account_activation_token
 from benchmarks.views.index import get_context
@@ -153,18 +153,12 @@ class Upload(View):
         assert self.domain is not None
         if request.user.is_anonymous:
             return HttpResponseRedirect(f'../profile/{self.domain}')
-        if self.domain == "language":
-            form = UploadFileFormLanguage()
-        else:
-            form = UploadFileForm()
+        form = UploadFileForm()
         return render(request, 'benchmarks/upload.html', {'form': form, 'domain': self.domain})
 
     def post(self, request):
         assert self.domain is not None
-        if self.domain == "language":
-            form = UploadFileFormLanguage(request.POST, request.FILES)
-        else:
-            form = UploadFileForm(request.POST, request.FILES)
+        form = UploadFileForm(request.POST, request.FILES)
         if not form.is_valid():
             return HttpResponse("Form is invalid", status=400)
 


### PR DESCRIPTION
This is just a quick hot fix to remove the private submission option as well as the old brain/base model submission option in Vision. 

This PR is a minimal change - the rest (making it in line with Language) is addressed in #224.