### PR TITLE
add check for spaces in validate zip

### DIFF
--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -242,6 +242,12 @@ def is_submission_original(file, submitter: User) -> Tuple[bool, Union[None, Lis
 def validate_zip(file):
     with zipfile.ZipFile(file, mode="r") as archive:
         namelist = archive.infolist()
+
+        # Check for spaces in file names
+        for item in namelist:
+            if ' ' in item.filename:
+                return False, f"File '{item.filename}' contains spaces. Please remove spaces from all file names."
+                
         root = namelist[0]
         has_plugin, submitted_plugins = plugins_exist(namelist)
         if not has_plugin:


### PR DESCRIPTION
This PR checks for spaces in files within zip submission, and outputs a specific error for users. Prior to this fix, plug-in only changes were wrongly flagged as non plug in changes because file names were being split by spaces. 

Closes issue #231 