### PR TITLE
Fixes duplicate model 500 error on submission

### DIFF
--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -250,7 +250,7 @@ def is_submission_original(file, submitter: User) -> Tuple[bool, Union[None, Lis
 
                 # check if an entry with the given identifier exists
                 if db_table.objects.filter(**query_filter).exists():
-                    owner_obj = db_table.objects.get(**query_filter)
+                    owner_obj = db_table.objects.filter(**query_filter).first()
                     owner_id = getattr(owner_obj, 'owner_id', None) or getattr(owner_obj, 'owner').id
 
                     # check to see if the submitter is the owner (or superuser)


### PR DESCRIPTION
Previously, when submitting a model that has multiple DB entires (such as alexnet), the prod server would 500 due to the QueryFilter not returning multiple models. 

This fixes that by forcing the Query to return the first model it finds. So for multiple models, this only returns the first one, and for a single model, it will return itself. Should fix 500 error. 