### PR TITLE
Speed up loading time for home page 

### DIFF
--- a/benchmarks/templates/benchmarks/base.html
+++ b/benchmarks/templates/benchmarks/base.html
@@ -32,7 +32,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% compress css %}
-    <link type="text/x-sass" rel="stylesheet" href="{% static "/benchmarks/css/main.sass" %}?{% now "U" %}" charset="utf-8">
+        <link type="text/x-sass" rel="stylesheet" href="{% static "/benchmarks/css/main.sass" %}" charset="utf-8">
     {% endcompress %}
 
     {# libraries #}

--- a/static/benchmarks/css/main.sass
+++ b/static/benchmarks/css/main.sass
@@ -12,6 +12,10 @@
 @import "unsubscribe"
 @import "v2"
 @import "tutorial"
+@import "components/banner"
+@import "components/info-section"
+@import "components/left-sidebar"
+@import "leaderboard/leaderboard-table"
 
 main.content
   margin-top: 75px


### PR DESCRIPTION
Removes the data time addition for the compressor object, which forced SASS to be compiled on _every_ load of base.html.