### PR TITLE
added user email and domain args to resubmit job links

### DIFF
--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -462,8 +462,10 @@ def submit_to_jenkins(request, domain, model_name, benchmarks=None):
     request_url = f"{jenkins_url}/job/{job_name}/buildWithParameters" \
                   f"?token=trigger2scoreAmodel" \
                   f"&user_id={request.user.id}" \
+                  f"&email={request.user.email}" \
                   f"&new_benchmarks={benchmark_string}" \
                   f"&new_models={model_name}" \
+                  f"&domain={domain}" \
                   f"&specified_only=True"
     _logger.debug(f"request_url: {request_url}")
 


### PR DESCRIPTION
Addresses issue [here](https://github.com/brain-score/vision/issues/714) in BSV. Also adds the user email to the URL in order for the email to be sent to the correct user on resubmission, modeling the [call](https://github.com/brain-score/brain-score.web/blob/1d2fc267ab8ad7600ce98d8b38d4f2975bc1042f/benchmarks/views/user.py#L223) to Jenkins in the Upload view. 