### PR TITLE
limit plugins for soft release to 1

### DIFF
--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -30,7 +30,7 @@ _logger = logging.getLogger(__name__)
 
 User = get_user_model()
 
-PLUGIN_LIMIT = 5  # used to limit the amount of plugins that can be submitted at once by a user
+PLUGIN_LIMIT = 1  # used to limit the amount of plugins that can be submitted at once by a user
 
 
 class Activate(View):


### PR DESCRIPTION
Some memory issues occurred while the limit was 5. During soft release the limit will be decreased to 1.