### PR TITLE
Minor update for full tutorial link

### DIFF
--- a/benchmarks/templates/benchmarks/competition2024.html
+++ b/benchmarks/templates/benchmarks/competition2024.html
@@ -177,7 +177,7 @@
             To facilitate benchmark submission, we provide
             <a target="_blank" href="https://github.com/brain-score/vision">helper code</a>
             and
-            <a target="_blank" href="https://brain-score.readthedocs.io/en/latest/modules/benchmark_tutorial.html">
+            <a target="_blank" href="https://www.brain-score.org/tutorials/models">
                 tutorials</a>.
             You can also use existing datasets or metrics and re-combine them in novel ways.
             Note that by using the Brain-Score platform, no model knowledge is required --
@@ -364,7 +364,7 @@
             and submit a benchmark. You can submit a benchmark by sending in a zip file on the website.
             For new datasets, you can either host yourself or reach out to us and we will give you access to S3.
             <span class="has-text-weight-bold">
-            Please check our <a target="_blank" href="../tutorial/">overview tutorials</a>
+            Please check our <a target="_blank" href="../tutorials/">overview tutorials</a>
             as well as our <a target="_blank"
                               href="https://www.brain-score.org/tutorials/benchmarks">full length tutorial</a>
             for detailed information about the submission process</span>.
@@ -507,8 +507,8 @@
                     <div class="list-item-title">Can I also submit models?</div>
                     <div class="list-item-description">
                         Brain-Score always accepts model submissions.
-                        See <a href="../tutorial/">here</a> and
-                        <a href="https://brain-score.readthedocs.io/en/latest/modules/model_tutorial.html">here</a>
+                        See <a href="../tutorials/">here</a> and
+                        <a href="https://www.brain-score.org/tutorials/models">here</a>
                         for tutorials.
                         Note that this competition is aimed at benchmarks though, and there are no prizes for models in
                         this edition.

--- a/benchmarks/templates/benchmarks/competition2024.html
+++ b/benchmarks/templates/benchmarks/competition2024.html
@@ -366,7 +366,7 @@
             <span class="has-text-weight-bold">
             Please check our <a target="_blank" href="../tutorial/">overview tutorials</a>
             as well as our <a target="_blank"
-                              href="https://brain-score.readthedocs.io/en/latest/modules/benchmark_tutorial.html">full length tutorial</a>
+                              href="https://www.brain-score.org/tutorials/benchmarks">full length tutorial</a>
             for detailed information about the submission process</span>.
         </p>
         <p>


### PR DESCRIPTION
Very small update - change link from https://brain-score.readthedocs.io/en/latest/modules/benchmark_tutorial.html to https://www.brain-score.org/tutorials/benchmarks