### PR TITLE
Add Leaderboard CSV download

### DIFF
--- a/benchmarks/templates/benchmarks/base.html
+++ b/benchmarks/templates/benchmarks/base.html
@@ -64,6 +64,7 @@
     <script defer src="{% static "/benchmarks/js/password_effect.js" %}"></script>
     <script defer src="{% static "/benchmarks/js/countdown.js" %}"></script>
     <script defer src="{% static "/benchmarks/js/collapsible_faq.js" %}"></script>
+    <script defer src="{% static "/benchmarks/js/download_csv.js" %}"></script>
     {% endcompress %}
 
     <script type="application/ld+json">

--- a/benchmarks/templates/benchmarks/leaderboard/info-section.html
+++ b/benchmarks/templates/benchmarks/leaderboard/info-section.html
@@ -1,3 +1,5 @@
+{% load static %}
+
 <div class="box">
   <h3 class="title">How to Interpret</h3>
   <div class="content">
@@ -6,6 +8,9 @@
       alignment between model and collected data), on every benchmark available. Benchmarks are arranged hierarchically,
       with scores for each child benchmark averaged together to create the overall score for the parent.
     </p>
+    <button id="download-csv" class="button button-ghost">Download CSV</button>
+    <textarea id="csv-data" style="display:none;">{{ csv_downloadable }}</textarea>
+    <script src="{% static 'js/download_csv.js' %}" defer></script>
   </div>
 </div>
 

--- a/static/benchmarks/js/download_csv.js
+++ b/static/benchmarks/js/download_csv.js
@@ -1,0 +1,25 @@
+ document.getElementById('download-csv').addEventListener('click', function () {
+            // Get the CSV data from the hidden textarea
+            const csvData = document.getElementById('csv-data').value;
+
+            // Create a blob with the CSV data
+            const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
+
+            // Create a link element
+            const link = document.createElement('a');
+
+            if (navigator.msSaveBlob) { // For IE 10+
+                navigator.msSaveBlob(blob, 'benchmark_scores.csv');
+            } else {
+                // Create a URL for the blob and set it as the href attribute
+                const url = URL.createObjectURL(blob);
+                link.setAttribute('href', url);
+                link.setAttribute('download', 'benchmark_scores.csv');
+                link.style.visibility = 'hidden';
+
+                // Append the link to the document and trigger the download
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+            }
+        });


### PR DESCRIPTION
This PR adds a way to download the CSV data for model ceiled scores. It is cached and domain-independent, but is mostly a quick and dirty way to do this. 