### PR TITLE
add csv download to profile as well

### DIFF
--- a/benchmarks/templates/benchmarks/landing_page.html
+++ b/benchmarks/templates/benchmarks/landing_page.html
@@ -31,10 +31,7 @@
         </div>
     </div>
 </nav>
-
-<div class=" container my_container landing
-mt-6 {# only while having 2024 competition message above #}
-">
+<div class=" container my_container landing">
     <div class="columns">
         <div class="left_side column is-half has-text-centered-mobile">
             <img class="logo_green image is-inline-block"  src="{% static "/benchmarks/img/logo_name_full.png" %}" />

--- a/benchmarks/templates/benchmarks/profile.html
+++ b/benchmarks/templates/benchmarks/profile.html
@@ -35,7 +35,11 @@
         <p class="benefits_info is-size-5-mobile">
             Past scores are below. Submissions are located at the bottom.
         </p>
+
         </form>
+        <button id="download-csv" class="button button-ghost">Download CSV</button>
+        <textarea id="csv-data" style="display:none;">{{ csv_downloadable }}</textarea>
+        <script src="{% static 'js/download_csv.js' %}" defer></script>
     </div>
 
     <div class="box leaderboard-table-component">


### PR DESCRIPTION
1. Allows users to download CSV data via the profile for their own models
2. Fixes an issue with removing the competition banner where the colored block was too far up the landing page 