### PR TITLE
Mobile Site Styling  Hotfixes

### DIFF
--- a/benchmarks/templates/benchmarks/base.html
+++ b/benchmarks/templates/benchmarks/base.html
@@ -29,7 +29,7 @@
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=1024">
 
     {% compress css %}
         <link type="text/x-sass" rel="stylesheet" href="{% static "/benchmarks/css/main.sass" %}" charset="utf-8">
@@ -65,6 +65,7 @@
     <script defer src="{% static "/benchmarks/js/countdown.js" %}"></script>
     <script defer src="{% static "/benchmarks/js/collapsible_faq.js" %}"></script>
     <script defer src="{% static "/benchmarks/js/download_csv.js" %}"></script>
+    <script defer src="{% static "/benchmarks/js/mobile_warning.js" %}"></script>
     {% endcompress %}
 
     <script type="application/ld+json">
@@ -100,6 +101,9 @@
     <meta name="twitter:image" content="{{logo_url}}">
 
     <title>{{title}}</title>
+
+
+
 </head>
 
 <body>

--- a/benchmarks/templates/benchmarks/base.html
+++ b/benchmarks/templates/benchmarks/base.html
@@ -29,6 +29,7 @@
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
+    <!-- Force desktop site, even on mobile -->
     <meta name="viewport" content="width=1024">
 
     {% compress css %}
@@ -107,8 +108,17 @@
 </head>
 
 <body>
+    <div id="mobile-warning-modal" class="mobile-warning-modal is-hidden">
+        <div class="modal-content">
+          <p>You're viewing Brain-Score on a mobile device. For the best experience — featuring interactive benchmarks and
+              detailed visualizations — we recommend using a desktop. You can still proceed with the mobile version below.</p>
+          <button id="dismiss-modal-btn" class="button button-primary">Proceed with Mobile Version</button>
+        </div>
+    </div>
     <main>
-        {% block main %}{% endblock %}
+        <div id="main-content" class="main-content">
+            {% block main %}{% endblock %}
+        </div>
     </main>
 </body>
 

--- a/benchmarks/templates/benchmarks/components/app-view.html
+++ b/benchmarks/templates/benchmarks/components/app-view.html
@@ -24,7 +24,7 @@
   </div>
 
   <div class="columns main-content">
-    <div class="column is-three-quarters">
+    <div class="column is-three-quarters main-cell">
       {% block content %}{% endblock %}
     </div>
 

--- a/benchmarks/templates/benchmarks/leaderboard/leaderboard.html
+++ b/benchmarks/templates/benchmarks/leaderboard/leaderboard.html
@@ -11,5 +11,7 @@
 {% endblock %}
 
 {% block info_section %}
-  {% include "benchmarks/leaderboard/info-section.html" %}
+  <div class="info-section">
+    {% include "benchmarks/leaderboard/info-section.html" %}
+  </div>
 {% endblock %}

--- a/static/benchmarks/css/components/info-section.sass
+++ b/static/benchmarks/css/components/info-section.sass
@@ -8,3 +8,25 @@
       font-weight: bold
       font-size: 1.5em
       color: $brainscore_green
+
+
+  // Hide info section on screens below 1024px (mobile and tablet)
+  @media (max-width: 1024px)
+    display: none
+
+// expand table to full width on mobile
+.column.is-three-quarters.main-cell
+   @media (max-width: 1024px)
+    width: 100%
+    position: absolute
+    left: 0
+
+.banner.box.gradient
+  @media (max-width: 1024px)
+    width: 146%
+    margin-left: -45%
+    //position: absolute
+    //left: 0
+
+
+

--- a/static/benchmarks/css/components/left-sidebar.sass
+++ b/static/benchmarks/css/components/left-sidebar.sass
@@ -34,3 +34,8 @@
 
     &.selected
       border-right: 8px solid $brainscore_green
+
+    // Hide info section on screens below 1024px (mobile and tablet)
+  @media (max-width: 1024px)
+    display: none
+

--- a/static/benchmarks/css/main.sass
+++ b/static/benchmarks/css/main.sass
@@ -16,6 +16,7 @@
 @import "components/info-section"
 @import "components/left-sidebar"
 @import "leaderboard/leaderboard-table"
+@import "other.sass"
 
 main.content
   margin-top: 75px

--- a/static/benchmarks/css/other.sass
+++ b/static/benchmarks/css/other.sass
@@ -1,0 +1,51 @@
+// Main content to blur (everything except the modal)
+#main-content
+  transition: filter 0.3s ease
+
+
+// Modal styles
+.mobile-warning-modal
+  position: fixed
+  top: 0
+  left: 0
+  width: 100vw
+  height: 100vh
+  display: flex
+  align-items: center
+  justify-content: center
+  background-color: rgba(0, 0, 0, 0.5) // semi-transparent background
+  z-index: 1000
+
+  .modal-content
+    background: white
+    padding: 20px
+    border-radius: 8px
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1)
+    text-align: center
+
+    p
+      margin-bottom: 20px
+      font-size: 1.25rem
+      font-weight: bold
+
+
+    button
+      padding: 10px 20px
+      font-size: 1rem
+      border: none
+      cursor: pointer
+
+
+
+
+// Apply blur effect only to the main content
+.is-blurred
+  #main-content
+    filter: blur(5px)
+
+
+
+// Hide modal when it's dismissed
+.is-hidden
+  display: none
+

--- a/static/benchmarks/js/mobile_warning.js
+++ b/static/benchmarks/js/mobile_warning.js
@@ -1,0 +1,32 @@
+document.addEventListener("DOMContentLoaded", function () {
+  console.log("DOM fully loaded and parsed");
+
+  // Function to detect mobile devices using the user agent
+  function isMobileDevice() {
+    return /Mobi|Android|iPhone|iPad|iPod/.test(navigator.userAgent);
+  }
+
+  // Detect if the user is on a mobile device
+  if (isMobileDevice()) {
+    console.log("Mobile device detected");
+
+    const modal = document.getElementById('mobile-warning-modal');
+    const mainContent = document.querySelector('main');
+    const dismissBtn = document.getElementById('dismiss-modal-btn');
+
+    // Show the modal and blur the background
+    modal.classList.remove('is-hidden');
+    mainContent.classList.add('is-blurred');
+
+    console.log("Modal displayed, background blurred");
+
+    // Remove blur and hide modal when the user clicks the button
+    dismissBtn.addEventListener('click', function () {
+      modal.classList.add('is-hidden');
+      mainContent.classList.remove('is-blurred');
+      console.log("Modal dismissed, blur removed");
+    });
+  } else {
+    console.log("Desktop or non-mobile device detected, no modal");
+  }
+});


### PR DESCRIPTION
- [x] Forces Desktop site on all devices, regardless of all screen sizes
- [x] If mobile screen size, remove left sidebar and right sections, fill leaderboard and header to screen
- [x] if mobile screen size, add popup that blurs background and displays message informing user that Brain-Score is best viewed on mobile, while still allowing them to proceed 