### PR TITLE
Fixing user documentation and removing backkports.zoneinfo from requi…

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-   python: "3.8"
+   python: "3.11"
 
 python:
    install:

--- a/docs/source/modules/brain-score_web.rst
+++ b/docs/source/modules/brain-score_web.rst
@@ -19,7 +19,7 @@ Brain Score Administrators:
 
 Once you have these values, continue by ensuring you are using ``<= python@3.8``. You can do this by first checking if you have 3.8 installed::
 
-    python3.8 --version
+    python3.11 --version
 
 And if not, install it::
 
@@ -28,7 +28,7 @@ And if not, install it::
 
 Next, create and activate a virtual environment::
 
-    python3.8 -m venv <env_name>
+    python3.11 -m venv <env_name>
     source <env_name>/bin/activate
 
 Then, clone the repository and change to the ``brain-score.web`` directory::

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-backports.zoneinfo==0.2.1
 boto3==1.28.15
 botocore==1.31.15
 certifi==2023.7.22


### PR DESCRIPTION
Mike or Kartik,

Only use this if you want to have users use 3.11 when running the website locally.

Fixed user documentation and removed backports.zoneinfo from requirements.txt to use Python 3.11 when running the website locally.

