### PR TITLE
Fix broken links following tutorial updates

### DIFF
--- a/benchmarks/templates/benchmarks/faq.html
+++ b/benchmarks/templates/benchmarks/faq.html
@@ -109,8 +109,8 @@
         </p>
         <p class="benefits_info is-size-5-mobile shorter no_top">
             We have created two tutorials outlining how to submit a new Brain-Score plugin-  a
-            (<a href="https://www.brain-score.org/tutorial/quickstart">Quickstart tutorial</a>)  and
-            three (<a href="https://www.brain-score.org/tutorial/deepdive_1">Deep Dive tutorials</a>).
+            (<a href="https://www.brain-score.org/tutorials/models/quickstart">Quickstart tutorial</a>)  and
+            three (<a href="https://www.brain-score.org/tutorials/models/deepdive_1">Deep Dive tutorials</a>).
             The Quickstart tutorial outlines how to set up your local environment quickly and how to run the pipeline
             locally. The Deep Dive tutorials contain direction on how to submit plugins and even provide a template
             plugin file.


### PR DESCRIPTION
Address Issue #350.

Fixed Quickstart tutorial and Deep Dive tutorial links. Currently there are only two deep dives, but I have left `three` in the description as a new Deep dive is in the works.