### PR TITLE
Add last updated status under leaderboard legend

### DIFF
--- a/benchmarks/templates/benchmarks/leaderboard/legend.html
+++ b/benchmarks/templates/benchmarks/leaderboard/legend.html
@@ -2,4 +2,7 @@
     <label>Score Legend</label>
     <span>Min Alignment</span>
     <span class="legend-right">Max Alignment</span>
+    <div class="cache-status">
+        Last updated: {{ last_updated }}
+    </div>
 </div>

--- a/benchmarks/templates/benchmarks/leaderboard/legend.html
+++ b/benchmarks/templates/benchmarks/leaderboard/legend.html
@@ -1,8 +1,14 @@
+{% load static %}
+
 <div class="legend">
     <label>Score Legend</label>
     <span>Min Alignment</span>
     <span class="legend-right">Max Alignment</span>
     <div class="cache-status">
-        Last updated: {{ last_updated }}
+        Last updated: <span class="last-updated-time" data-timestamp="{{ last_updated }}"></span>
     </div>
 </div>
+
+{% block js%}
+  <script defer src="{% static 'benchmarks/js/cache-status.js' %}"></script>
+{% endblock %}

--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -15,6 +15,8 @@ from django.shortcuts import render
 from django.template.defaulttags import register
 from django.views.decorators.cache import cache_page
 from tqdm import tqdm
+from django.utils import timezone
+import pytz
 
 from benchmarks.models import BenchmarkType, BenchmarkInstance, Model, Score, generic_repr, Reference
 
@@ -85,10 +87,22 @@ def cache_get_context(timeout=24 * 60 * 60):  # 24 hour cache by default
             
             # Store result in cache appropriately (i.e., for users or globally)
             cache.set(cache_key, result, timeout)
+            # Store last updated time for leaderboard
+            cache.set('leaderboard_last_updated', timezone.now())
             return result
 
         return wrapper
     return decorator
+
+# Add a helper function to get the last update time
+def get_cache_last_updated():
+    last_updated = cache.get('leaderboard_last_updated')
+    if last_updated:
+        # Convert to EST
+        est = pytz.timezone('US/Eastern')
+        last_updated = last_updated.astimezone(est)
+        return last_updated.strftime('%Y-%m-%d %I:%M %p EST')
+    return 'Never'
 
 # Keep leaderboard caching for now.
 @cache_page(24 * 60 * 60)
@@ -97,6 +111,9 @@ def view(request, domain: str):
     public_context = get_context(domain=domain, show_public=True)
     # Cache leaderboard context that is ultimately rendered in the leaderboard view
     leaderboard_context = get_context(domain=domain)
+    # Add last updated time to context
+    leaderboard_context['last_updated'] = get_cache_last_updated()
+
     return render(request, 'benchmarks/leaderboard/leaderboard.html', leaderboard_context)
 
 # get_context is used for both leaderboard and model views. We can cache the results of it so that after the first

--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -98,10 +98,9 @@ def cache_get_context(timeout=24 * 60 * 60):  # 24 hour cache by default
 def get_cache_last_updated():
     last_updated = cache.get('leaderboard_last_updated')
     if last_updated:
-        # Convert to EST
-        est = pytz.timezone('US/Eastern')
-        last_updated = last_updated.astimezone(est)
-        return last_updated.strftime('%Y-%m-%d %I:%M %p EST')
+        # ISO format for javascript to convert to local time
+        return last_updated.isoformat()
+    # If the cache is empty, return 'Never' (This should never happen)
     return 'Never'
 
 # Keep leaderboard caching for now.

--- a/static/benchmarks/css/leaderboard/leaderboard-table.sass
+++ b/static/benchmarks/css/leaderboard/leaderboard-table.sass
@@ -76,6 +76,13 @@
           color: #008CBA
           text-decoration: underline
 
+    .cache-status
+        position: absolute
+        bottom: -25px
+        right: 0
+        font-size: 0.8em
+        color: #666
+
 .leaderboard-table-container
   overflow-x: scroll
 

--- a/static/benchmarks/js/cache-status.js
+++ b/static/benchmarks/js/cache-status.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const element = document.querySelector('.last-updated-time');
+    if (!element) return;
+    
+    const timestamp = element.dataset.timestamp;
+    if (timestamp === 'Never') {
+        element.textContent = 'Never';
+        return;
+    }
+
+    try {
+        const date = new Date(timestamp);
+        // Convert Isoformat to readable local time format
+        element.textContent = date.toLocaleString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: true,
+            timeZoneName: 'short'
+        });
+        element.title = date.toString();
+    } catch (e) {
+        // If there is an error, just show the isoformat timestamp
+        element.textContent = timestamp;
+        console.error('Error formatting date:', e);  // Log error for debugging
+    }
+});


### PR DESCRIPTION
"Nice to have" feature that displays when the leaderboard was last updated in the user's local time.

Might be useful for users who have submitted a model, that has been scored (indicated by the email), but hasn't shown up on the leaderboard yet.

![image](https://github.com/user-attachments/assets/b69137cb-7e5f-442d-908e-4ec635f581ef)
