### PR TITLE
Add leaderboard view parameters to URL

### DIFF
--- a/benchmarks/templates/benchmarks/base.html
+++ b/benchmarks/templates/benchmarks/base.html
@@ -15,11 +15,12 @@
     <!-- Global Site Tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-89541187-2"></script>
     <script>
+        const GTAG_ID = 'UA-89541187-2';
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-89541187-2');
+        gtag('config', GTAG_ID);
     </script>
 
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -81,6 +81,8 @@ all_domain_urls = [non_domain_urls]
 for domain in supported_domains:
     domain_urls = [
         path(f'{domain}/', partial(index, domain=domain), name='index'),
+     path(f'{domain}/leaderboard/', partial(index, domain=domain), name=f'{domain}-leaderboard'),
+
         path(f'profile/{domain}/', user.Profile.as_view(domain=domain), name=f'{domain}-information'),
         path(f'profile/{domain}/submit/', user.Upload.as_view(domain=domain), name=f'{domain}-submit'),
         path(f'profile/<str:domain>/resubmit/', partial(user.resubmit, domain=domain), name=f'resubmit'),

--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -2,6 +2,7 @@ import functools
 from functools import partial
 from django.conf import settings
 from django.urls import path
+from django.shortcuts import redirect
 
 from .views import index, user, model, competition2022, competition2024, compare, community, release2_0, brain_model, \
     content_utils, benchmark, explore
@@ -80,8 +81,9 @@ all_domain_urls = [non_domain_urls]
 
 for domain in supported_domains:
     domain_urls = [
-        path(f'{domain}/', partial(index, domain=domain), name='index'),
-     path(f'{domain}/leaderboard/', partial(index, domain=domain), name=f'{domain}-leaderboard'),
+        #path(f'{domain}/', partial(index, domain=domain), name='index'),
+     path(f'{domain}/', lambda request: redirect(f'leaderboard/', permanent=True)),
+        path(f'{domain}/leaderboard/', partial(index, domain=domain), name=f'{domain}-leaderboard'),
 
         path(f'profile/{domain}/', user.Profile.as_view(domain=domain), name=f'{domain}-information'),
         path(f'profile/{domain}/submit/', user.Upload.as_view(domain=domain), name=f'{domain}-submit'),

--- a/static/benchmarks/js/table-expansion.js
+++ b/static/benchmarks/js/table-expansion.js
@@ -4,6 +4,17 @@ $(document).ready(function () {
 
     if (document.querySelector('.leaderboard-table-component')) {
         $('th[data-benchmark]').click(onClickExpandCollapseBenchmark);
+        
+        // Parse URL parameters and set initial state
+        const urlParams = new URLSearchParams(window.location.search);
+        const benchmark = urlParams.get('benchmark');
+
+        if (benchmark) {
+            const targetElement = $(`[data-benchmark="${benchmark}"]`)[0];
+            if (targetElement) {
+                expandParent({ currentTarget: targetElement });
+            }
+        }
         return;
     }
 
@@ -29,6 +40,19 @@ $(document).ready(function () {
             expandParent(event);
         }
 
+        let benchmark = event.currentTarget.dataset.benchmark;
+
+        // If expanding, set the URL to the parent benchmark
+        if (!isClosed) {
+            const parentBenchmark = event.currentTarget.dataset.parent;
+            if (parentBenchmark) {
+                benchmark = parentBenchmark.replace('_v0', '');
+            }
+        }
+
+        const newUrl = `/${domain}/leaderboard/?benchmark=${benchmark}`;
+        console.log("New URL:", newUrl); // Debugging log
+        updateUrlAndTrackView(newUrl);
     }
 
     function expandChild(event) {
@@ -87,5 +111,14 @@ $(document).ready(function () {
             });
         });
     }
+    // Function to update the URL and send a pageview to Google Analytics
+    function updateUrlAndTrackView(newUrl) {
+        // Update the URL without reloading the page
+        history.pushState(null, '', newUrl);
 
+        // Send a pageview event to Google Analytics
+        gtag('config', GTAG_ID, {
+            'page_path': newUrl
+        });
+    }
 });

--- a/static/benchmarks/js/table-expansion.js
+++ b/static/benchmarks/js/table-expansion.js
@@ -5,17 +5,20 @@ $(document).ready(function () {
     if (document.querySelector('.leaderboard-table-component')) {
         $('th[data-benchmark]').click(onClickExpandCollapseBenchmark);
         
-        // Parse URL parameters and set initial state
-        const urlParams = new URLSearchParams(window.location.search);
-        const benchmark = urlParams.get('benchmark');
+        // Get URL parameters immediately
+        const benchmark = new URLSearchParams(window.location.search).get('benchmark');
+        if (!benchmark) return;
 
-        if (benchmark) {
-            const targetElement = $(`[data-benchmark="${benchmark}"]`)[0];
+        // Use requestAnimationFrame to wait for cache to load
+        requestAnimationFrame(() => {
+            const targetElement = document.querySelector(`[data-benchmark="${benchmark}"]`);
             if (targetElement) {
-                expandParent({ currentTarget: targetElement });
+                onClickExpandCollapseBenchmark({
+                    currentTarget: targetElement,
+                    type: "initial-load"
+                });
             }
-        }
-        return;
+        });
     }
 
     function onClickExpandCollapseBenchmark(event) {
@@ -51,8 +54,7 @@ $(document).ready(function () {
         }
 
         const newUrl = `/${domain}/leaderboard/?benchmark=${benchmark}`;
-        console.log("New URL:", newUrl); // Debugging log
-        updateUrlAndTrackView(newUrl);
+        updateUrl(newUrl);
     }
 
     function expandChild(event) {
@@ -112,7 +114,7 @@ $(document).ready(function () {
         });
     }
     // Function to update the URL and send a pageview to Google Analytics
-    function updateUrlAndTrackView(newUrl) {
+    function updateUrl(newUrl) {
         // Update the URL without reloading the page
         history.pushState(null, '', newUrl);
 

--- a/static/benchmarks/js/table-expansion.js
+++ b/static/benchmarks/js/table-expansion.js
@@ -5,8 +5,8 @@ $(document).ready(function () {
     if (document.querySelector('.leaderboard-table-component')) {
         $('th[data-benchmark]').click(onClickExpandCollapseBenchmark);
         
-        // Get URL parameters immediately
-        const benchmark = new URLSearchParams(window.location.search).get('benchmark');
+        // Get URL parameters
+        const benchmark = new URLSearchParams(window.location.search).get('parent-benchmark');
         if (!benchmark) return;
 
         // Use requestAnimationFrame to wait for cache to load
@@ -53,7 +53,7 @@ $(document).ready(function () {
             }
         }
 
-        const newUrl = `/${domain}/leaderboard/?benchmark=${benchmark}`;
+        const newUrl = `/${domain}/leaderboard/?parent-benchmark=${benchmark}`;
         updateUrl(newUrl);
     }
 


### PR DESCRIPTION
Do not merge yet. Still building out other filters.

- Added leaderboard expansion views as URL parameter
- Still need to add filter as URL parameter
- Want to introduce a function that builds URL that can be reused

**URL**
<img width="702" alt="image" src="https://github.com/user-attachments/assets/71fcaf01-d100-465e-9928-53172e6fdc8a" />

<img width="1766" alt="image" src="https://github.com/user-attachments/assets/046cbea8-f6da-4dce-bb47-742c5046fb9d" />
