### PR TITLE
Fix for color issue on website

### DIFF
--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -570,7 +570,7 @@ def normalize_alpha(value, min_value, max_value):
     slope = -.9 / (min_value - max_value)
     intercept = .1 - slope * min_value
     result = slope * value + intercept
-    return result
+    return float(result)
 
 
 def represent(value):


### PR DESCRIPTION
### Issue
Scores are showing up in harsher colors than expected. The error comes from a stray `np . float` added into the opacity for each score chip, which stems from changes to the [float type](https://numpy.org/devdocs/release/2.2.0-notes.html#changes:~:text=The%20type%20annotations%20of%20numpy.float64%20and%20numpy.complex128%20now%20reflect%20that%20they%20are%20also%20subtypes%20of%20the%20built%2Din%20float%20and%20complex%20types%2C%20respectively.%20This%20update%20prevents%20static%20type%2Dcheckers%20from%20reporting%20errors%20in%20cases%20such%20as%3A) in the most recent version of numpy.

##### Example
<img width="500" alt="image" src="https://github.com/user-attachments/assets/aff8403d-6cb9-4389-bc7e-99a9c2c8827a" />

The easy fix is to cast to float. However, this does highlight that the deployed version of the website does not have pinned versions of libraries (unlike current localhost setups) as the docker container uses conda and the `environment.yaml` instead of `requirements.txt`. Might be worth considering pinning all version for conda or changing the localhost approach.


