### PR TITLE
Change default DB to use migrated DB

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -128,7 +128,7 @@ def get_db_info():
                 'PORT': '5432'
             }
         }
-    db_secret_name = os.getenv("DB_CRED", "brainscore-1-ohio-cred")
+    db_secret_name = os.getenv("DB_CRED", "brainscore-1-ohio-cred-migrated")
     try:
         secrets = get_secret(db_secret_name, REGION_NAME)
         DATABASES = {


### PR DESCRIPTION
Changes the default database's URL from `brainscore-1-ohio-cred` to `brainscore-1-ohio-cred-migrated`. Note that this is the dev db, not prod or test. All three DBs were changed in the EB Configurator.