### PR TITLE
Add region layer mapping information to deep dive 2

### DIFF
--- a/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
+++ b/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
@@ -226,6 +226,9 @@
 5           "IT": "fc" 
 6       }
     </code></pre>
+
+    Importantly, when using the JSON file approach, each layer-mapping for each model identifier must be contained in its own JSON file and be named <span class="special_format">{model_identifier}.json</span>.
+
     </p>
     <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
         While optional, we <b>recommend</b> specifying this mapping for models with layers designed to replicate specific brain regions.

--- a/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
+++ b/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
@@ -198,14 +198,16 @@
 </div>
 <div class="box leaderboard-table-component">
     <h3 class="benefits_heading is-size-3-mobile">Part 7: Exploring the (optional) Region-Layer Mapping</h3>
-    <p class="benefits_info is-size-5-mobile shorter">
+    <p class="benefits_info is-size-5-mobile">
         Brain-Score allows users to specify a region-layer mapping for models. This mapping assigns a specific layer from <span class="special_format">model.py</span> file 
         to a particular brain region, ensuring it remains fixed when evaluated across different benchmarks.
     </p>
-    <p class="benefits_info is-size-5-mobile shorter">
-        We provide two methods for specifying a region-layer mapping:<br><br>
-            1. (The preferred method) Passing a <span class="special_format">region_layer_mapping</span> argument in your <span class="special_format">__init__.py</span> model_registry 
-            entry (<a href="https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/models/voneresnet_50_3/__init__.py#L8">Example</a>).
+    <p class="benefits_info is-size-5-mobile">
+        We provide two methods for specifying a region-layer mapping:
+    </p>
+    <ol class="benefits_info is-size-5-mobile ordered_list">
+        <li>(The preferred method) Passing a <span class="special_format">region_layer_mapping</span> argument in your <span class="special_format">__init__.py</span> model_registry 
+            entry (<a href="https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/models/voneresnet_50_3/__init__.py#L8">Example</a>).</li>
 
     <pre class="modified_1"><code>
 1       model_registry['resnet50_tutorial'] = lambda: ModelCommitment(identifier='resnet50_tutorial', 
@@ -215,8 +217,8 @@
 
     </code></pre><br>
 
-            2. Providing a <span class="special_format">{model_identifier}.json</span> file in a <span class="special_format">region_layer_map/</span> 
-            folder within your submission package (<a href="https://github.com/brain-score/vision/tree/master/brainscore_vision/models/resnet50_tutorial/region_layer_map">Example</a>).
+        <li>Providing a <span class="special_format">{model_identifier}.json</span> file in a <span class="special_format">region_layer_map/</span> 
+            folder within your submission package (<a href="https://github.com/brain-score/vision/tree/master/brainscore_vision/models/resnet50_tutorial/region_layer_map">Example</a>).</li>
 
     <pre class="modified_1"><code>
 1       {
@@ -226,22 +228,25 @@
 5           "IT": "fc" 
 6       }
     </code></pre>
+    </ol>
 
     Importantly, when using the JSON file approach, each layer-mapping for each model identifier must be contained in its own JSON file and be named <span class="special_format">{model_identifier}.json</span>.
 
     </p>
-    <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
+    <p class="benefits_info is-size-5-mobile has-text-weight-bold is-italic">
         While optional, we <b>recommend</b> specifying this mapping for models with layers designed to replicate specific brain regions.
         If pre-committed, the layer names must match those returned by the <span class="special_format">get_layers()</span> function in the <span class="special_format">model.py</span>.
     </p>
-    <p class="benefits_info is-size-5-mobile shorter">
-        Note: If a submission does not include a <span class="special_format">region_layer_mapping</span> JSON file, the layer mapping will be automatically computed before scoring using
-        <a href=""https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/model_helpers/brain_transformation/__init__.py#L13">STANDARD_REGION_BENCHMARKS</a>.
+    <p class="benefits_info is-size-5-mobile">
+        <b>Note:</b> If a submission does not include a <span class="special_format">region_layer_mapping</span> JSON file, the layer mapping will be automatically computed before scoring using
+        <a href="https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/model_helpers/brain_transformation/__init__.py#L13">STANDARD_REGION_BENCHMARKS</a>.
+    </p>
+    <p class="benefits_info is-size-5-mobile ordered_list">
         This standard mappping assigns layers to each region <b>independently</b>, meaning:
         <li>A region does not need to be mapped to a unique layer.</li>
         <li>Regions do not have to follow a specific order.</li>
     </p>
-    <p class="benefits_info is-size-5-mobile shorter">
+    <p class="benefits_info is-size-5-mobile">
         This intentional flexibility is particularly relevant for models with layers that were intended to replicate specific brain regions, as there is no guarantee that the layer names will match the region names unless pre-committed.
         As such, for this types of models, we  <b>strongly recommend</b> specifying a region-layer mapping.
     </p>

--- a/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
+++ b/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
@@ -197,7 +197,49 @@
     </code></pre>
 </div>
 <div class="box leaderboard-table-component">
-    <h3 class="benefits_heading is-size-3-mobile">Part 7: Exploring an (optional) requirements.txt  File</h3>
+    <h3 class="benefits_heading is-size-3-mobile">Part 7: Exploring the (optional) Region-Layer Mapping</h3>
+    <p class="benefits_info is-size-5-mobile shorter">
+        Brain-Score allows users to specify a region-layer mapping for models. This is where a specific layer of a model provided by the <span class="special_format">model.py</span> file is 
+        committed to a specific region of the brain and does not change when scored against different benchmarks. 
+    </p>
+    <p class="benefits_info is-size-5-mobile shorter">
+        We provide two methods for specifying a region-layer mapping:<br><br>
+            1. (The preferred method) Passing a <span class="special_format">region_layer_mapping</span> argument in your <span class="special_format">__init__.py</span> model_registry 
+            entry (<a href="https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/models/voneresnet_50_3/__init__.py#L8">Example</a>).
+
+    <pre class="modified_1"><code>
+1       model_registry['resnet50_tutorial'] = lambda: ModelCommitment(identifier='resnet50_tutorial', 
+2           activations_model=get_model('resnet50_tutorial'), 
+3           layers=get_layers('resnet50_tutorial'), 
+4           region_layer_mapping={"V1": "layer1", "V2": "layer3", "V4": "layer4", "IT": "fc"})
+
+    </code></pre><br>
+
+            2. Providing a <span class="special_format">{model_identifier}.json</span> file in a <span class="special_format">region_layer_map/</span> 
+            folder in your submission package (<a href="https://github.com/brain-score/vision/tree/master/brainscore_vision/models/resnet50_tutorial/region_layer_map">Example</a>).
+
+    <pre class="modified_1"><code>
+1       {
+2           "V1": "layer1", 
+3           "V2": "layer3", 
+4           "V4": "layer4",
+5           "IT": "fc" 
+6       }
+    </code></pre>
+    </p>
+    <p class="benefits_info is-size-5-mobile shorter">
+        While this is optional, we recommend providing this information for models that may have specific layers that were designed to replicate specific regions of the brain.
+
+        If pre-committed, the layer names must match layer names that are returned by the <span class="special_format">get_layers()</span> function in the model.py file.
+    </p>
+    <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
+        Note: If submissions do not include a region_layer_mapping JSON file, layer mapping will be computed upon submission prior to scoring using 
+        <a href=""https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/model_helpers/brain_transformation/__init__.py#L13">STANDARD_REGION_BENCHMARKS</a>.
+        This is especially relevant to models with layers that were designed to replicate specific regions of the brain, as there is no guarantee that the layer names will match the region names unless pre-committed.
+    </p>
+</div>
+<div class="box leaderboard-table-component">
+    <h3 class="benefits_heading is-size-3-mobile">Part 8: Exploring an (optional) requirements.txt  File</h3>
     <p class="benefits_info is-size-5-mobile shorter">
         The (optional) <a href="https://github.com/brain-score/vision/blob/master/brainscore_vision/models/resnet50_tutorial/requirements.txt">requirements.txt file</a>
         is where you can add any requirements that your model needs (such as a specific version of a package or an external git
@@ -214,7 +256,7 @@
     </p>
 </div>
 <div class="box leaderboard-table-component">
-    <h3 class="benefits_heading is-size-3-mobile">Part 8: Putting it All Together </h3>
+    <h3 class="benefits_heading is-size-3-mobile">Part 9: Putting it All Together </h3>
     <p class="benefits_info is-size-5-mobile shorter">
         You are almost done! If you were actually submitting a model, the final step prior to submission would be to run
         your model locally to ensure that everything is in working order. You can do this by first following the
@@ -266,7 +308,7 @@ Process finished with exit code 0
 </div>
 
 <div class="box leaderboard-table-component">
-    <h3 class="benefits_heading is-size-3-mobile">Part 9: Model Summary Tools</h3>
+    <h3 class="benefits_heading is-size-3-mobile">Part 10: Model Summary Tools</h3>
     <p class="benefits_info is-size-5-mobile shorter">
         For models built using PyTorch, the <span class="special_format">torchsummary</span>
         package can be utilized to get a summary of model information. Install it via pip if necessary

--- a/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
+++ b/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
@@ -199,8 +199,8 @@
 <div class="box leaderboard-table-component">
     <h3 class="benefits_heading is-size-3-mobile">Part 7: Exploring the (optional) Region-Layer Mapping</h3>
     <p class="benefits_info is-size-5-mobile shorter">
-        Brain-Score allows users to specify a region-layer mapping for models. This is where a specific layer of a model provided by the <span class="special_format">model.py</span> file is 
-        committed to a specific region of the brain and does not change when scored against different benchmarks. 
+        Brain-Score allows users to specify a region-layer mapping for models. This mapping assigns a specific layer from <span class="special_format">model.py</span> file 
+        to a particular brain region, ensuring it remains fixed when evaluated across different benchmarks.
     </p>
     <p class="benefits_info is-size-5-mobile shorter">
         We provide two methods for specifying a region-layer mapping:<br><br>
@@ -216,7 +216,7 @@
     </code></pre><br>
 
             2. Providing a <span class="special_format">{model_identifier}.json</span> file in a <span class="special_format">region_layer_map/</span> 
-            folder in your submission package (<a href="https://github.com/brain-score/vision/tree/master/brainscore_vision/models/resnet50_tutorial/region_layer_map">Example</a>).
+            folder within your submission package (<a href="https://github.com/brain-score/vision/tree/master/brainscore_vision/models/resnet50_tutorial/region_layer_map">Example</a>).
 
     <pre class="modified_1"><code>
 1       {
@@ -228,15 +228,19 @@
     </code></pre>
     </p>
     <p class="benefits_info is-size-5-mobile shorter">
-        While this is optional, we recommend providing this information for models that may have specific layers that were designed to replicate specific regions of the brain.
-
-        If pre-committed, the layer names must match layer names that are returned by the <span class="special_format">get_layers()</span> function in the model.py file.
+        While optional, we <b>recommend</b> specifying this mapping for models with layers designed to replicate specific brain regions.
+        If pre-committed, the layer names must match those returned by the <span class="special_format">get_layers()</span> function in the <span class="special_format">model.py</span>.
     </p>
     <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
-        Note: If submissions do not include a region_layer_mapping JSON file, layer mapping will be computed upon submission prior to scoring using 
+        Note: If a submission does not include a <span class="special_format">region_layer_mapping</span> JSON file, the layer mapping will be automatically computed before scoring using
         <a href=""https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/model_helpers/brain_transformation/__init__.py#L13">STANDARD_REGION_BENCHMARKS</a>.
-        Standard region-layer mapping is performed for each region independent of other regions. As such, we do not enforce each region must be mapped to a unique layer or that regions followed a particular order.
-        This is especially relevant to models with layers that were designed to replicate specific regions of the brain, as there is no guarantee that the layer names will match the region names unless pre-committed.
+        This standard mappping assigns layers to each region <b>independently</b>, meaning:
+    </p>
+        <li><b><i>A region does not need to be mapped to a unique layer.</i></b></li>
+        <li><b><i>Regions do not have to follow a specific order.</i></b></li>
+    <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
+        This intentional flexibility is particularly relevant for models with layers that were intended to replicate specific brain regions, as there is no guarantee that the layer names will match the region names unless pre-committed.
+        As such, for this types of models, we  <b>strongly recommend</b> specifying a region-layer mapping.
     </p>
 </div>
 <div class="box leaderboard-table-component">

--- a/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
+++ b/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
@@ -227,18 +227,18 @@
 6       }
     </code></pre>
     </p>
-    <p class="benefits_info is-size-5-mobile shorter">
+    <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
         While optional, we <b>recommend</b> specifying this mapping for models with layers designed to replicate specific brain regions.
         If pre-committed, the layer names must match those returned by the <span class="special_format">get_layers()</span> function in the <span class="special_format">model.py</span>.
     </p>
-    <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
+    <p class="benefits_info is-size-5-mobile shorter">
         Note: If a submission does not include a <span class="special_format">region_layer_mapping</span> JSON file, the layer mapping will be automatically computed before scoring using
         <a href=""https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/model_helpers/brain_transformation/__init__.py#L13">STANDARD_REGION_BENCHMARKS</a>.
         This standard mappping assigns layers to each region <b>independently</b>, meaning:
+        <li>A region does not need to be mapped to a unique layer.</li>
+        <li>Regions do not have to follow a specific order.</li>
     </p>
-        <li><b><i>A region does not need to be mapped to a unique layer.</i></b></li>
-        <li><b><i>Regions do not have to follow a specific order.</i></b></li>
-    <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
+    <p class="benefits_info is-size-5-mobile shorter">
         This intentional flexibility is particularly relevant for models with layers that were intended to replicate specific brain regions, as there is no guarantee that the layer names will match the region names unless pre-committed.
         As such, for this types of models, we  <b>strongly recommend</b> specifying a region-layer mapping.
     </p>

--- a/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
+++ b/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
@@ -235,6 +235,7 @@
     <p class="benefits_info is-size-5-mobile shorter has-text-weight-bold is-italic">
         Note: If submissions do not include a region_layer_mapping JSON file, layer mapping will be computed upon submission prior to scoring using 
         <a href=""https://github.com/brain-score/vision/blob/39b214b9201cf067b4aa9b67777bf9c063871fe0/brainscore_vision/model_helpers/brain_transformation/__init__.py#L13">STANDARD_REGION_BENCHMARKS</a>.
+        Standard region-layer mapping is performed for each region independent of other regions. As such, we do not enforce each region must be mapped to a unique layer or that regions followed a particular order.
         This is especially relevant to models with layers that were designed to replicate specific regions of the brain, as there is no guarantee that the layer names will match the region names unless pre-committed.
     </p>
 </div>

--- a/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
+++ b/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
@@ -199,7 +199,7 @@
 <div class="box leaderboard-table-component">
     <h3 class="benefits_heading is-size-3-mobile">Part 7: Exploring the (optional) Region-Layer Mapping</h3>
     <p class="benefits_info is-size-5-mobile">
-        Brain-Score allows users to specify a region-layer mapping for models. This mapping assigns a specific layer from <span class="special_format">model.py</span> file 
+        Brain-Score allows users to specify a region-layer mapping for models. This mapping assigns a specific layer from the <span class="special_format">model.py</span> file 
         to a particular brain region, ensuring it remains fixed when evaluated across different benchmarks.
     </p>
     <p class="benefits_info is-size-5-mobile">

--- a/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
+++ b/benchmarks/templates/benchmarks/tutorials/models/deepdive_2.html
@@ -248,7 +248,7 @@
     </p>
     <p class="benefits_info is-size-5-mobile">
         This intentional flexibility is particularly relevant for models with layers that were intended to replicate specific brain regions, as there is no guarantee that the layer names will match the region names unless pre-committed.
-        As such, for this types of models, we  <b>strongly recommend</b> specifying a region-layer mapping.
+        As such, for these types of models, we  <b>strongly recommend</b> specifying a region-layer mapping.
     </p>
 </div>
 <div class="box leaderboard-table-component">


### PR DESCRIPTION
Currently, region-layer-mapping is including in the `resnet50_tutorial` package and a key component of Brain-Score however there is no mention of it in the tutorials.

Added a section in Deep Dive 2 that draws attention to it, particularly the importance of explicitly pre-specifying the commitment for certain models that have an implicit layer mapping.

More details should be added about how to perform this layer mapping process locally. Will be added when Jupyter Notebook uses are available on the website. For now, I think this is sufficient. 

I think formatting could use some improvement. Fielding opinions.

![image](https://github.com/user-attachments/assets/552885b4-280a-494b-9930-2d8bb4971a98)