### PR TITLE
Clear all cache on request

### DIFF
--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -189,6 +189,7 @@ def refresh_cache(request: HttpRequest, domain: str = "vision") -> JsonResponse:
     
     # Invalidate cache by incrementing version
     new_version = invalidate_domain_cache(domain)
+    cache.clear()
     
     # Optionally rebuild the cache immediately
     rebuild = request.GET.get('rebuild', 'false').lower() == 'true' # Get rebuild parameter from URL

--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -45,7 +45,7 @@ def get_base_model_query(domain="vision"):
 # Cache the leaderboard HTML page for 15 minutes at a time
 # Server-side HTML caching until leaderboard views are introduced.
 # Consider using client-side caching in the future
-#@cache_page(1 * 15 * 60)
+@cache_page(24 * 60 * 60)
 def view(request, domain: str):
     # Get the authenticated user if any
     user = request.user if request.user.is_authenticated else None

--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -42,9 +42,8 @@ def get_base_model_query(domain="vision"):
     return FinalModelContext.objects.filter(domain=domain)  # Return QuerySet instead of list
 
 
-# Cache the leaderboard HTML page for 15 minutes at a time
+# Cache the leaderboard HTML page
 # Server-side HTML caching until leaderboard views are introduced.
-# Consider using client-side caching in the future
 @cache_page(24 * 60 * 60)
 def view(request, domain: str):
     # Get the authenticated user if any


### PR DESCRIPTION
This is a small amendment to the Optimized Leaderboard Generation PR #379.

For some reason, dev and prod servers are not demonstrating the full performance gains seen locally across all developers. At first, @mike-ferguson and I thought this could be due to EB server hardware. However, upon a quick instance upgrade, the leaderboard was still taking ~10 seconds on second load instead of the ~1.5 seconds (after dictionary caching). This needs further exploration. 

As a temporary fix, I am re-introducing `@cache_page` HTML caching. I am also introducing a `cache.clear()` call in the `refresh_cache()` function. This now invalidates not only the dictionary cache but also the HTML cache upon materialized view refresh after scoring completion and rebuilds it appropriately. 


### How to test this PR
1. Visit leaderboard at localhost:8000/vision
2. Visit leaderboard again and ensure that caching works (i.e., doesn't query database and serves HTML cache) -- loads instantaneously
3. Obtain your token (localhost:8000/debug/show_token)
4. Refresh cache by visiting localhost:8000/refresh_cache/vision/?token={**your token**}&rebuild=False
5. Visit leaderboard and make sure that it queries database this time -- slowest load
6. Refresh cache by visiting localhost:8000/refresh_cache/vision/?token={**your token**}&rebuild=True
7. Visit leaderboard and make sure that it doesn't query database and loads almost as fast as HTML caching -- loads within 1 second

{ } brackets should not be used ----- localhost:8000/refresh_cache/vision/?token=ABCDEFGH12345&rebuild=True