### PR TITLE
Add data_publicly_available to MV query

### DIFF
--- a/benchmarks/sql/mv.sql
+++ b/benchmarks/sql/mv.sql
@@ -206,6 +206,7 @@ jsonb_build_object(
     'num_subjects', bdm.num_subjects,
     'pre_processing', bdm.pre_processing,
     'brainscore_link', bdm.brainscore_link,
+    'data_publicly_available', bdm.data_publicly_available,
     'extra_notes', bdm.extra_notes
   ) AS benchmark_data_meta,
   jsonb_build_object(


### PR DESCRIPTION
Pretty self-explanatory. Original `mv.sql` contained runnable for models, and now will add a similar field for benchmark data metadata table.

