### PR TITLE
Fix model card information

### DIFF
--- a/benchmarks/templates/benchmarks/model.html
+++ b/benchmarks/templates/benchmarks/model.html
@@ -44,46 +44,6 @@
 
 {# Right-hand info #}
 {% block info_section %}
-    {% if submission_details_visible %}
-        <div class="box">
-            <span class='fine_print'>The following information is only visible to you (the model owner):</span><br><br>
-            <span class='information'>Model Name:</span> {{ model.name }}<br>
-            <span class='information'>Submitted By:</span> {{ model.submitter }}<br>
-            <span class='information'>Submitted On:</span> {{ model.timestamp }}<br>
-            <span class='information'>Domain:</span> {{ model.domain }}<br>
-            <br>
-            <span class='information'>Console Log:</span>
-
-            {% if model.submission_id < 302 %}
-                <a class="log_link"
-                   href="http://braintree.mit.edu:8080/job/run_benchmarks/{{ model.jenkins_id }}/consoleText">View
-                    Console Log</a> <br>
-                <span class='fine_print'>
-                    This is an older model, so a parsed (interactive) console log will not be available <br>
-                    until the model is re-run on a new submission. In the meantime, you can still
-                    view a plaintext version with the link provided. <br>
-                </span>
-            {% else %}
-                {% if model.build_status == "successful" or model.build_status == "failure" %}
-                    <a class="log_link"
-                       href="http://braintree.mit.edu:8080/job/run_benchmarks/{{ model.jenkins_id }}/parsed_console/job/run_benchmarks/{{ model.submission_id }}/parsed_console/log.html">View
-                        Console Log</a> <br>
-
-                {% elif model.build_status == "running" %}
-                    <span class='fine_print'><br>
-                        This model's build status is shown as still running; thus, the console log below
-                        <br> will not be interactive until the model is done running. In the meantime, you can still
-                        view a plaintext version <br> with the link provided. <br>
-                    </span>
-                    <a class="log_link"
-                       href="http://braintree.mit.edu:8080/job/run_benchmarks/{{ model.jenkins_id }}/consoleText">View
-                        Console Log</a>
-                    <br><br>
-                {% endif %}
-            {% endif %}
-        </div>
-    {% endif %}
-
     <div class="box">
         <div class="card-content">
             <p class="subtitle is-5">

--- a/benchmarks/views/model.py
+++ b/benchmarks/views/model.py
@@ -159,9 +159,19 @@ def add_benchmark_rankings(model, reference_context):
             
         try:
             score_value = float(score_ceiled)
-            other_scores = benchmark_scores.get(versioned_benchmark_id, [])
-            better_scores = [s for s in other_scores if s > score_value]
-            score['rank'] = len(better_scores) + 1
+            all_scores = benchmark_scores.get(versioned_benchmark_id, [])
+            # Sort scores in descending order and find the rank
+            sorted_scores = sorted(all_scores, reverse=True)
+            # Find the position of the current score (1-indexed)
+            # If there are ties, all tied scores get the same rank
+            rank = 1
+            for i, s in enumerate(sorted_scores):
+                if s > score_value:
+                    rank = i + 2  # +2 because we want 1-indexed and we're looking for the next position
+                elif s == score_value:
+                    rank = i + 1  # +1 for 1-indexed
+                    break
+            score['rank'] = rank
         except (ValueError, TypeError):
             score['rank'] = 'N/A'
 


### PR DESCRIPTION
Based on a previous change to leaderboard, model card per-benchmark ranking broke when logged in. This resulted in model cards (only after being logged in) to reflect per-benchmark ranks as 1 even if untrue. This has now been fixed with correct per-benchmark ranks.

Additionally, materialized view return submitter information in an incorrect format. This format was on display when viewing submitter information. I have chosen to remove the section entirely because much of the information is not useful or incompatible after the post-AWS migration.

