### PR TITLE
One-click citation list based on leaderboard view

### DIFF
--- a/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard.html
+++ b/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard.html
@@ -37,7 +37,12 @@
         <div class="filter-column benchmark-column">
           <div class="filter-column-header">
             <h4>Included Benchmarks</h4>
-            <a href="#" id="resetBenchmarksLink" class="reset-link">Reset</a>
+            <div class="header-actions">
+              <button id="copyBibtexBtn" class="btn-icon" title="Copy BibTeX citations for selected benchmarks">
+                📖
+              </button>
+              <a href="#" id="resetBenchmarksLink" class="reset-link">Reset</a>
+            </div>
           </div>
           <div id="benchmarkFilterPanel"></div>
         </div>
@@ -397,6 +402,17 @@
             // Trigger update
             if (typeof applyCombinedFilters === 'function') {
               applyCombinedFilters();
+            }
+          });
+        }
+        
+        // Setup the copy bibtex button
+        const copyBibtexBtn = document.getElementById('copyBibtexBtn');
+        if (copyBibtexBtn) {
+          copyBibtexBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            if (typeof copyBibtexToClipboard === 'function') {
+              copyBibtexToClipboard();
             }
           });
         }

--- a/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard.html
+++ b/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard.html
@@ -230,10 +230,13 @@
     src="https://cdn.jsdelivr.net/npm/ag-grid-community@33.2.4/dist/ag-grid-community.min.js">
   </script>
 
-  {# 2) Load your grid-wrapper JS (where you define initializeGrid) #}
+  {# 2) Load tooltip component JS #}
+  <script src="{% static 'benchmarks/js/components/tooltip.js' %}"></script>
+
+  {# 3) Load your grid-wrapper JS (where you define initializeGrid) #}
   <script src="{% static 'benchmarks/js/ag-grid-leaderboard.js' %}"></script>
 
-  {# 3) Kick it off once the DOM is ready #}
+  {# 4) Kick it off once the DOM is ready #}
   <script>
   document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM loaded, starting initialization...');

--- a/benchmarks/views/leaderboard.py
+++ b/benchmarks/views/leaderboard.py
@@ -305,7 +305,8 @@ def ag_grid_leaderboard(request, domain: str):
                 'raw': score.get('score_raw'),
                 'error': score.get('error'),
                 'color': score.get('color'),
-                'complete': score.get('is_complete', True)
+                'complete': score.get('is_complete', True),
+                'benchmark': score.get('benchmark', {})  # Include benchmark metadata for bibtex collection
             }
         row_data.append(rd)
 
@@ -433,7 +434,5 @@ def ag_grid_leaderboard(request, domain: str):
     filtered_benchmarks = [b for b in context['benchmarks'] if b.identifier != 'average_vision_v0']
     context['benchmark_tree'] = json.dumps(build_benchmark_tree(filtered_benchmarks))
 
-    # debugging
-    print("🔍 Django filter_options being sent:", context.get('filter_options', 'NOT FOUND'))
     # 5) Render the AG-Grid template
     return render(request, 'benchmarks/leaderboard/ag-grid-leaderboard.html', context)

--- a/static/benchmarks/css/components/tooltip.sass
+++ b/static/benchmarks/css/components/tooltip.sass
@@ -1,0 +1,94 @@
+// Tooltip component styling
+//
+// Usage:
+// .tooltip                  - Base tooltip class
+// .tooltip-success         - Green tooltip for success messages
+// .tooltip-error           - Red tooltip for error messages  
+// .tooltip-warning         - Blue tooltip for warning messages
+// .tooltip-info            - Default gray tooltip for info messages
+// .tooltip-bottom          - Position arrow on bottom (tooltip appears below element)
+// .tooltip-left            - Position arrow on left (tooltip appears to left of element)
+// .tooltip-right           - Position arrow on right (tooltip appears to right of element)
+//
+// JavaScript usage (requires /js/components/tooltip.js):
+// createTooltip(element, message, { type: 'success', position: 'bottom' })
+// showTooltip('elementId', message, 'error') // backward compatibility
+// addHoverTooltip(element, message, options) // hover tooltips
+// <div data-tooltip="Message" data-tooltip-type="info"> // HTML attribute tooltips
+
+.tooltip
+  background: #333
+  color: white
+  padding: 8px 12px
+  border-radius: 4px
+  font-size: 0.875rem
+  font-weight: 500
+  white-space: nowrap
+  opacity: 0
+  animation: tooltipFadeIn 0.2s ease-out forwards
+  position: fixed
+  z-index: 10000
+  
+  // Tooltip arrow
+  &::after
+    content: ''
+    position: absolute
+    top: 100%
+    left: 50%
+    transform: translateX(-50%)
+    border: 5px solid transparent
+    border-top-color: #333
+  
+  // Tooltip variants
+  &.tooltip-success
+    background: #22c55e
+    
+    &::after
+      border-top-color: #22c55e
+  
+  &.tooltip-error
+    background: #ef4444
+    
+    &::after
+      border-top-color: #ef4444
+  
+  &.tooltip-warning
+    background: #5C8DB8
+    
+    &::after
+      border-top-color: #5C8DB8
+  
+  &.tooltip-info
+    background: #333
+    
+    &::after
+      border-top-color: #333
+
+// Tooltip fade-in animation
+@keyframes tooltipFadeIn
+  from
+    opacity: 0
+    transform: translateX(-50%) translateY(-100%) translateY(-5px)
+  to
+    opacity: 1
+    transform: translateX(-50%) translateY(-100%)
+
+// Alternative positioning classes
+.tooltip-bottom
+  &::after
+    top: auto
+    bottom: 100%
+    transform: translateX(-50%) rotate(180deg)
+
+.tooltip-left
+  &::after
+    top: 50%
+    left: 100%
+    transform: translateY(-50%) rotate(-90deg)
+
+.tooltip-right
+  &::after
+    top: 50%
+    left: auto
+    right: 100%
+    transform: translateY(-50%) rotate(90deg) 

--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -1043,6 +1043,81 @@ button,
     margin-top: 0.3rem
     font-style: italic
 
+.header-actions
+    display: flex
+    align-items: center
+    gap: 8px
+
+  .btn-icon
+    background: $primary-color
+    color: white
+    border: none
+    border-radius: 4px
+    padding: 6px 8px
+    font-size: 16px
+    cursor: pointer
+    transition: all 0.2s ease
+    min-width: 32px
+    height: 32px
+    display: flex
+    align-items: center
+    justify-content: center
+
+    &:hover
+      background: darken($primary-color, 10%)
+      transform: translateY(-1px)
+
+    &:active
+      transform: translateY(0)
+
+// Bibtex tooltip styling
+.bibtex-tooltip
+  background: #333
+  color: white
+  padding: 8px 12px
+  border-radius: 4px
+  font-size: 0.875rem
+  font-weight: 500
+  white-space: nowrap
+  opacity: 0
+  animation: tooltipFadeIn 0.2s ease-out forwards
+  
+  // Tooltip arrow
+  &::after
+    content: ''
+    position: absolute
+    top: 100%
+    left: 50%
+    transform: translateX(-50%)
+    border: 5px solid transparent
+    border-top-color: #333
+  
+  &.bibtex-tooltip-success
+    background: #22c55e
+    
+    &::after
+      border-top-color: #22c55e
+  
+  &.bibtex-tooltip-error
+    background: #ef4444
+    
+    &::after
+      border-top-color: #ef4444
+  
+  &.bibtex-tooltip-warning
+    background: #5C8DB8
+    
+    &::after
+      border-top-color: #5C8DB8
+
+@keyframes tooltipFadeIn
+  from
+    opacity: 0
+    transform: translateX(-50%) translateY(-100%) translateY(-5px)
+  to
+    opacity: 1
+    transform: translateX(-50%) translateY(-100%)
+
 // Vision parent container styling
 .benchmark-node.vision-parent
   margin-bottom: 0.3rem

--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -1,5 +1,6 @@
 //@import "../../../node_modules/bulma/sass/utilities/mixins"
 @import 'gradient-theme'
+@import '../components/tooltip'
 
 // Base button styling (all buttons get basic styling)
 button,
@@ -1070,53 +1071,7 @@ button,
     &:active
       transform: translateY(0)
 
-// Bibtex tooltip styling
-.bibtex-tooltip
-  background: #333
-  color: white
-  padding: 8px 12px
-  border-radius: 4px
-  font-size: 0.875rem
-  font-weight: 500
-  white-space: nowrap
-  opacity: 0
-  animation: tooltipFadeIn 0.2s ease-out forwards
-  
-  // Tooltip arrow
-  &::after
-    content: ''
-    position: absolute
-    top: 100%
-    left: 50%
-    transform: translateX(-50%)
-    border: 5px solid transparent
-    border-top-color: #333
-  
-  &.bibtex-tooltip-success
-    background: #22c55e
-    
-    &::after
-      border-top-color: #22c55e
-  
-  &.bibtex-tooltip-error
-    background: #ef4444
-    
-    &::after
-      border-top-color: #ef4444
-  
-  &.bibtex-tooltip-warning
-    background: #5C8DB8
-    
-    &::after
-      border-top-color: #5C8DB8
 
-@keyframes tooltipFadeIn
-  from
-    opacity: 0
-    transform: translateX(-50%) translateY(-100%) translateY(-5px)
-  to
-    opacity: 1
-    transform: translateX(-50%) translateY(-100%)
 
 // Vision parent container styling
 .benchmark-node.vision-parent

--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -1048,7 +1048,7 @@ button,
     align-items: center
     gap: 8px
 
-  .btn-icon
+.btn-icon
     background: $primary-color
     color: white
     border: none

--- a/static/benchmarks/js/ag-grid-leaderboard.js
+++ b/static/benchmarks/js/ag-grid-leaderboard.js
@@ -2333,8 +2333,6 @@ function setInitialColumnState() {
   });
 }
 
-
-
 // Function to copy bibtex to clipboard with user feedback
 function copyBibtexToClipboard() {
   const bibtexList = collectBenchmarkBibtex();
@@ -2358,7 +2356,7 @@ function copyBibtexToClipboard() {
   });
 }
 
-// Function to collect unique bibtex citations from currently selected benchmarks
+// Function to collect unique bibtex citations for benchmarks that are not excluded
 function collectBenchmarkBibtex() {
   if (!window.originalRowData || window.originalRowData.length === 0) {
     return [];
@@ -2375,12 +2373,14 @@ function collectBenchmarkBibtex() {
   }
   
   // Use first model as reference for benchmark structure
+  // Assumes first model has no missing scores. leaderboard.py only creates fields for benchmarks where the model has scores.
+  // leaderboard.py serializes (i.e., flattens) the scores object, so the benchmark data is available at the top level.
   const firstModel = window.originalRowData[0];
   
   // Go through each field in the model data
   Object.keys(firstModel).forEach(fieldName => {
     // Skip non-benchmark fields
-    if (fieldName === 'model' || fieldName === 'rank' || fieldName === 'metadata') {
+    if (fieldName === 'id' || fieldName === 'rank' || fieldName === 'model' || fieldName === 'metadata') {
       return;
     }
     
@@ -2394,9 +2394,11 @@ function collectBenchmarkBibtex() {
         isLeafBenchmark(fieldName)) {
       
       // Check if this benchmark is excluded using multiple patterns
+      // Assumes string format is benchmarkName_v{version_number}
       const baseFieldName = fieldName.replace(/_v\d+$/, '');
       const benchmarkTypeId = scoreData.benchmark.benchmark_type_id;
       
+      // Makes sure that we do not include benchmarks that we have excluded.
       const isExcluded = excludedBenchmarks.has(fieldName) ||
                         excludedBenchmarks.has(baseFieldName) ||
                         excludedBenchmarks.has(benchmarkTypeId);

--- a/static/benchmarks/js/ag-grid-leaderboard.js
+++ b/static/benchmarks/js/ag-grid-leaderboard.js
@@ -2417,36 +2417,3 @@ function collectBenchmarkBibtex() {
   return Array.from(bibtexSet);
 }
 
-// Function to show tooltip feedback
-function showTooltip(elementId, message, type = 'info') {
-  const element = document.getElementById(elementId);
-  if (!element) return;
-  
-  // Remove any existing tooltip
-  const existingTooltip = document.querySelector('.bibtex-tooltip');
-  if (existingTooltip) {
-    existingTooltip.remove();
-  }
-  
-  // Create tooltip element
-  const tooltip = document.createElement('div');
-  tooltip.className = `bibtex-tooltip bibtex-tooltip-${type}`;
-  tooltip.textContent = message;
-  
-  // Position tooltip above the button
-  const rect = element.getBoundingClientRect();
-  tooltip.style.position = 'fixed';
-  tooltip.style.left = `${rect.left + (rect.width / 2)}px`;
-  tooltip.style.top = `${rect.top - 10}px`;
-  tooltip.style.transform = 'translateX(-50%) translateY(-100%)';
-  tooltip.style.zIndex = '10000';
-  
-  document.body.appendChild(tooltip);
-  
-  // Auto-remove after 2.5 seconds
-  setTimeout(() => {
-    if (tooltip.parentNode) {
-      tooltip.parentNode.removeChild(tooltip);
-    }
-  }, 2500);
-}

--- a/static/benchmarks/js/ag-grid-leaderboard.js
+++ b/static/benchmarks/js/ag-grid-leaderboard.js
@@ -2222,6 +2222,7 @@ window.decodeBenchmarkFilters = decodeBenchmarkFilters;
 window.buildHierarchyFromTree = buildHierarchyFromTree;
 window.updateColumnVisibility = updateColumnVisibility;
 window.setInitialColumnState = setInitialColumnState;
+window.copyBibtexToClipboard = copyBibtexToClipboard;
 
 // Update column visibility based on filtering state
 function updateColumnVisibility() {
@@ -2330,4 +2331,120 @@ function setInitialColumnState() {
   window.globalGridApi.applyColumnState({
     state: initialColumnState
   });
+}
+
+
+
+// Function to copy bibtex to clipboard with user feedback
+function copyBibtexToClipboard() {
+  const bibtexList = collectBenchmarkBibtex();
+  
+  if (bibtexList.length === 0) {
+    showTooltip('copyBibtexBtn', 'No citations found for selected benchmarks', 'warning');
+    return;
+  }
+  
+  // Format as a single string with double line breaks between entries
+  const formattedBibtex = bibtexList.join('\n\n');
+  
+  // Copy to clipboard
+  navigator.clipboard.writeText(formattedBibtex).then(() => {
+    const count = bibtexList.length;
+    const message = `Copied ${count} citation${count === 1 ? '' : 's'} to clipboard`;
+    showTooltip('copyBibtexBtn', message, 'success');
+  }).catch(err => {
+    console.error('Failed to copy to clipboard:', err);
+    showTooltip('copyBibtexBtn', 'Failed to copy to clipboard', 'error');
+  });
+}
+
+// Function to collect unique bibtex citations from currently selected benchmarks
+function collectBenchmarkBibtex() {
+  if (!window.originalRowData || window.originalRowData.length === 0) {
+    return [];
+  }
+
+  const excludedBenchmarks = new Set(window.filteredOutBenchmarks || []);
+  const hierarchyMap = window.benchmarkTree ? buildHierarchyFromTree(window.benchmarkTree) : new Map();
+  const bibtexSet = new Set();
+  
+  // Helper function to determine if a benchmark is a leaf (has no children)
+  function isLeafBenchmark(benchmarkId) {
+    const children = hierarchyMap.get(benchmarkId) || [];
+    return children.length === 0;
+  }
+  
+  // Use first model as reference for benchmark structure
+  const firstModel = window.originalRowData[0];
+  
+  // Go through each field in the model data
+  Object.keys(firstModel).forEach(fieldName => {
+    // Skip non-benchmark fields
+    if (fieldName === 'model' || fieldName === 'rank' || fieldName === 'metadata') {
+      return;
+    }
+    
+    const scoreData = firstModel[fieldName];
+    
+    // Check if this is a leaf benchmark with bibtex data
+    if (scoreData && 
+        typeof scoreData === 'object' && 
+        scoreData.benchmark && 
+        scoreData.benchmark.bibtex &&
+        isLeafBenchmark(fieldName)) {
+      
+      // Check if this benchmark is excluded using multiple patterns
+      const baseFieldName = fieldName.replace(/_v\d+$/, '');
+      const benchmarkTypeId = scoreData.benchmark.benchmark_type_id;
+      
+      const isExcluded = excludedBenchmarks.has(fieldName) ||
+                        excludedBenchmarks.has(baseFieldName) ||
+                        excludedBenchmarks.has(benchmarkTypeId);
+      
+      if (!isExcluded) {
+        const bibtex = scoreData.benchmark.bibtex.trim();
+        
+        // Add to set if valid (Set automatically handles duplicates)
+        if (bibtex && bibtex !== 'null') {
+          bibtexSet.add(bibtex);
+        }
+      }
+    }
+  });
+  
+  return Array.from(bibtexSet);
+}
+
+// Function to show tooltip feedback
+function showTooltip(elementId, message, type = 'info') {
+  const element = document.getElementById(elementId);
+  if (!element) return;
+  
+  // Remove any existing tooltip
+  const existingTooltip = document.querySelector('.bibtex-tooltip');
+  if (existingTooltip) {
+    existingTooltip.remove();
+  }
+  
+  // Create tooltip element
+  const tooltip = document.createElement('div');
+  tooltip.className = `bibtex-tooltip bibtex-tooltip-${type}`;
+  tooltip.textContent = message;
+  
+  // Position tooltip above the button
+  const rect = element.getBoundingClientRect();
+  tooltip.style.position = 'fixed';
+  tooltip.style.left = `${rect.left + (rect.width / 2)}px`;
+  tooltip.style.top = `${rect.top - 10}px`;
+  tooltip.style.transform = 'translateX(-50%) translateY(-100%)';
+  tooltip.style.zIndex = '10000';
+  
+  document.body.appendChild(tooltip);
+  
+  // Auto-remove after 2.5 seconds
+  setTimeout(() => {
+    if (tooltip.parentNode) {
+      tooltip.parentNode.removeChild(tooltip);
+    }
+  }, 2500);
 }

--- a/static/benchmarks/js/components/tooltip.js
+++ b/static/benchmarks/js/components/tooltip.js
@@ -1,0 +1,155 @@
+/**
+ * Tooltip Component JavaScript
+ * 
+ * A reusable tooltip utility for creating positioned tooltips with various styles.
+ * 
+ * Usage:
+ * - createTooltip(element, message, options) - Advanced usage with full configuration
+ * - showTooltip(elementId, message, type) - Simple usage for backward compatibility
+ */
+
+/**
+ * Creates a tooltip for the given element with advanced options
+ * @param {HTMLElement} element - DOM element to attach tooltip to
+ * @param {string} message - Text to display in tooltip
+ * @param {Object} options - Configuration object
+ * @param {string} options.type - Tooltip type: 'info', 'success', 'error', 'warning' (default: 'info')
+ * @param {string} options.position - Tooltip position: 'top', 'bottom', 'left', 'right' (default: 'top')
+ * @param {number} options.duration - Auto-hide duration in ms (default: 2500)
+ * @param {number} options.offset - Distance from element in pixels (default: 10)
+ * @returns {Object|null} Object with `element` and `remove()` method, or null if element is invalid
+ */
+function createTooltip(element, message, options = {}) {
+  const {
+    type = 'info',
+    position = 'top',
+    duration = 2500,
+    offset = 10
+  } = options;
+  
+  if (!element) return null;
+  
+  // Remove any existing tooltip
+  const existingTooltip = document.querySelector('.tooltip');
+  if (existingTooltip) {
+    existingTooltip.remove();
+  }
+  
+  // Create tooltip element
+  const tooltip = document.createElement('div');
+  tooltip.className = `tooltip tooltip-${type}`;
+  if (position !== 'top') {
+    tooltip.classList.add(`tooltip-${position}`);
+  }
+  tooltip.textContent = message;
+  
+  // Position tooltip
+  const rect = element.getBoundingClientRect();
+  
+  switch (position) {
+    case 'bottom':
+      tooltip.style.left = `${rect.left + (rect.width / 2)}px`;
+      tooltip.style.top = `${rect.bottom + offset}px`;
+      tooltip.style.transform = 'translateX(-50%)';
+      break;
+    case 'left':
+      tooltip.style.left = `${rect.left - offset}px`;
+      tooltip.style.top = `${rect.top + (rect.height / 2)}px`;
+      tooltip.style.transform = 'translateX(-100%) translateY(-50%)';
+      break;
+    case 'right':
+      tooltip.style.left = `${rect.right + offset}px`;
+      tooltip.style.top = `${rect.top + (rect.height / 2)}px`;
+      tooltip.style.transform = 'translateY(-50%)';
+      break;
+    default: // top
+      tooltip.style.left = `${rect.left + (rect.width / 2)}px`;
+      tooltip.style.top = `${rect.top - offset}px`;
+      tooltip.style.transform = 'translateX(-50%) translateY(-100%)';
+  }
+  
+  document.body.appendChild(tooltip);
+  
+  // Auto-remove after specified duration
+  const timeoutId = setTimeout(() => {
+    if (tooltip.parentNode) {
+      tooltip.parentNode.removeChild(tooltip);
+    }
+  }, duration);
+  
+  // Return tooltip element and cleanup function
+  return {
+    element: tooltip,
+    remove: () => {
+      clearTimeout(timeoutId);
+      if (tooltip.parentNode) {
+        tooltip.parentNode.removeChild(tooltip);
+      }
+    }
+  };
+}
+
+/**
+ * Simplified tooltip function for backward compatibility
+ * @param {string} elementId - ID of element to attach tooltip to
+ * @param {string} message - Text to display
+ * @param {string} type - Tooltip type (default: 'info')
+ * @returns {Object|null} Tooltip object or null if element not found
+ */
+function showTooltip(elementId, message, type = 'info') {
+  const element = document.getElementById(elementId);
+  return createTooltip(element, message, { type });
+}
+
+/**
+ * Creates a tooltip on hover for the given element
+ * @param {HTMLElement} element - Element to add hover tooltip to
+ * @param {string} message - Tooltip message
+ * @param {Object} options - Tooltip options (same as createTooltip)
+ */
+function addHoverTooltip(element, message, options = {}) {
+  if (!element) return;
+  
+  let currentTooltip = null;
+  
+  element.addEventListener('mouseenter', () => {
+    currentTooltip = createTooltip(element, message, {
+      ...options,
+      duration: 999999 // Don't auto-hide on hover
+    });
+  });
+  
+  element.addEventListener('mouseleave', () => {
+    if (currentTooltip) {
+      currentTooltip.remove();
+      currentTooltip = null;
+    }
+  });
+}
+
+/**
+ * Utility function to add tooltips to elements with data-tooltip attributes
+ * Usage: <button data-tooltip="Click me!" data-tooltip-type="info">Button</button>
+ */
+function initializeDataTooltips() {
+  document.querySelectorAll('[data-tooltip]').forEach(element => {
+    const message = element.getAttribute('data-tooltip');
+    const type = element.getAttribute('data-tooltip-type') || 'info';
+    const position = element.getAttribute('data-tooltip-position') || 'top';
+    
+    addHoverTooltip(element, message, { type, position });
+  });
+}
+
+// Auto-initialize data tooltips when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeDataTooltips);
+} else {
+  initializeDataTooltips();
+}
+
+// Make functions available globally
+window.createTooltip = createTooltip;
+window.showTooltip = showTooltip;
+window.addHoverTooltip = addHoverTooltip;
+window.initializeDataTooltips = initializeDataTooltips; 


### PR DESCRIPTION
Uses #398 as base.

## Description

Introduces a one-click citation list that is copy to clipboard based on current leaderboard view. Only supports benchmarks right now.

## Steps
`copyBibtexToClipboard()` function added to `ag-grid-leaderboard.js`. Should be modularized in the future. 
1. Function calls `collectBenchmarkBibtex()` which collects the a set of filtered out (i.e., excluded) benchmarks and the benchmark hierarchy tree. 
2. We get the row data from the first model (assumes first model has no missing scores), and iterate over its benchmarks. 
3. Check if benchmark is a benchmark, has a bibtex, and is a leaf (i.e., no children). 
4. If it is, check if it is in the list of excludedBenchmarks (after some string parsing). 
5. If not in excludedBenchmarks, add to bibtexSet (captures only unique bibtex). 
6. Then return bibtexSet and format it by adding double line breaks between each bibtex. 
7. Call showToolTip and write formatted bibtex to clipboard.
8. Add error or empty list handling to tool tip.

## Demo

https://github.com/user-attachments/assets/4ac82456-a56d-4676-8a3c-299f8e2ee881



## New Tooltip SASS and JS Component
Introduces `tooltip.sass` and `../js/components/tooltip.js` for future tooltip use.

### Setup

1. **Add to your SASS file:**
   ```sass
   @import 'components/tooltip'
   ```

2. **Add to your HTML template:**
   ```html
   <script src="{% static 'benchmarks/js/components/tooltip.js' %}"></script>
   ```

### Usage:

### Option 1: Click Tooltips

HTML
```html
<button id="copyBtn" onclick="handleCopy()">Copy</button>
```

JS
```javascript
function handleCopy() {
  // Your action here
  showTooltip('copyBtn', 'Copied!', 'success');
}
```

### Option 2: Hover Tooltips  

HTML
```html
<span id="helpIcon">?</span>
```

JS
```javascript
const helpIcon = document.getElementById('helpIcon');
addHoverTooltip(helpIcon, 'This explains the feature', { position: 'right' });
```

Can introduce this in `code_hover.js` for large file upload portal. In the future...