### PR TITLE
Update leaderboard overhaul header functionality and style

### DIFF
--- a/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard.html
+++ b/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard.html
@@ -244,6 +244,7 @@
         benchmarkTree = JSON.parse('{{ benchmark_tree|escapejs }}');
         filterOptions = JSON.parse('{{ filter_options|escapejs }}');
         benchmarkMetadata = JSON.parse('{{ benchmark_metadata|escapejs }}');
+        benchmarkIds = JSON.parse('{{ benchmark_ids|escapejs }}');
         console.log('All data loaded successfully, filter options:', filterOptions);
       } catch (e) {
         console.error('Error parsing data:', e);
@@ -254,6 +255,8 @@
       window.benchmarkTree = benchmarkTree;
       window.originalRowData = rowData;
       window.filterOptions = filterOptions;
+      window.benchmarkMetadata = benchmarkMetadata;
+      window.benchmarkIds = benchmarkIds;
       const ranges = filterOptions?.parameter_ranges || {};
       if (ranges.max_param_count) {
         document.getElementById('paramCountMin').max = ranges.max_param_count;
@@ -270,7 +273,6 @@
         document.getElementById('stimuliCountMax').max = ranges.max_stimuli_count;
         document.getElementById('stimuliCountMax').value = ranges.max_stimuli_count;
       }
-      window.benchmarkMetadata = benchmarkMetadata;
       
       // Initialize grid
       if (typeof initializeGrid === 'function') {

--- a/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard.html
+++ b/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard.html
@@ -322,19 +322,8 @@
           parseURLFilters();
         }
         
-        // If no explicit benchmark filters in URL, apply default (exclude engineering)
-        if (!hasExplicitBenchmarks) {
-          const engineeringCheckbox = document.querySelector('input[value="engineering_vision_v0"]');
-          if (engineeringCheckbox) {
-            engineeringCheckbox.checked = false;
-      
-            const engineeringNode = engineeringCheckbox.closest('.benchmark-node');
-            if (engineeringNode) {
-              const childCheckboxes = engineeringNode.querySelectorAll('input[type="checkbox"]');
-              childCheckboxes.forEach(cb => cb.checked = false);
-            }
-          }
-        }
+        // If no explicit benchmark filters in URL, use default (include all benchmarks)
+        // No special exclusions - all benchmarks are selected by default
         
         // Always rebuild exclusion set based on current checkbox states
         window.filteredOutBenchmarks = new Set();
@@ -367,26 +356,11 @@
           resetLink.addEventListener('click', (e) => {
             e.preventDefault();
             
-            // First, check all checkboxes
+            // Check all checkboxes (include all benchmarks by default)
             const allCheckboxes = document.querySelectorAll('#benchmarkFilterPanel input[type="checkbox"]');
             allCheckboxes.forEach(cb => {
-              cb.checked = true;  // Check everything first
+              cb.checked = true;  // Check everything including engineering
             });
-            
-            // Then, uncheck engineering and ALL its children
-            const engineeringCheckbox = document.querySelector('input[value="engineering_vision_v0"]');
-            if (engineeringCheckbox) {
-              engineeringCheckbox.checked = false;
-              
-              // Find the engineering node and uncheck all children recursively
-              const engineeringNode = engineeringCheckbox.closest('.benchmark-node');
-              if (engineeringNode) {
-                const childCheckboxes = engineeringNode.querySelectorAll('input[type="checkbox"]');
-                childCheckboxes.forEach(cb => {
-                  cb.checked = false;
-                });
-              }
-            }
             
             // Rebuild the exclusion set
             window.filteredOutBenchmarks = new Set();

--- a/benchmarks/views/leaderboard.py
+++ b/benchmarks/views/leaderboard.py
@@ -432,6 +432,13 @@ def ag_grid_leaderboard(request, domain: str):
     context['benchmark_metadata'] = json.dumps(benchmark_metadata_list)
     filtered_benchmarks = [b for b in context['benchmarks'] if b.identifier != 'average_vision_v0']
     context['benchmark_tree'] = json.dumps(build_benchmark_tree(filtered_benchmarks))
+    
+    # Create simple benchmark ID mapping for frontend navigation links
+    benchmark_ids = {}
+    for benchmark in context['benchmarks']:
+        if benchmark.id:  # Only include benchmarks with valid IDs
+            benchmark_ids[benchmark.identifier] = benchmark.id
+    context['benchmark_ids'] = json.dumps(benchmark_ids)
 
     # debugging
     print("🔍 Django filter_options being sent:", context.get('filter_options', 'NOT FOUND'))

--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -307,39 +307,21 @@ button,
   padding-right: 4px
   z-index: 11  // Higher than sorting area but lower than count badge
   transition: all 0.2s ease
-  color: #666
-  font-weight: bold
-  font-size: 16px !important  // Global 16px size for all sort indicators
+  font-size: 16px !important  // Match AG Grid default icon size
   
-  // Default state (neutral sort icon)
-  &[style*="opacity: 0.5"], &[style*="opacity: 0.6"]
-    color: #999
-    font-weight: normal
-  
-  // Active state (sorted)
-  &[style*="opacity: 1"]
-    color: #333
-    font-weight: bold
-
+  // Use AG Grid's built-in icon styling - inherit color from grid theme
+  &.ag-icon
+    color: inherit
+    display: inline-block
+    
   &:hover
     transform: scale(1.1)
-    color: #000
 
-// White sort indicators for neural and behavior headers (dark backgrounds)
+// White sort icons for neural and behavior headers (dark backgrounds)
 .expandable-header.neural .sort-indicator,
 .expandable-header.behavior .sort-indicator
   color: white !important
   
-  // Default state for dark backgrounds
-  &[style*="opacity: 0.5"], &[style*="opacity: 0.6"]
-    color: rgba(255, 255, 255, 0.6) !important
-    font-weight: normal
-  
-  // Active state for dark backgrounds
-  &[style*="opacity: 1"]
-    color: white !important
-    font-weight: bold
-
   &:hover
     transform: scale(1.1)
     color: white !important
@@ -380,6 +362,8 @@ button,
 .ag-header-cell:hover .ag-header-cell-resize
   background-color: rgba(0, 0, 0, 0.1) // light gray on hover
   cursor: col-resize
+
+
 
 #benchmarkFilterPanel
   width: 100%

--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -1,4 +1,4 @@
-//@import "../../../node_modules/bulma/sass/utilities/mixins"
+
 @import '../variables'
 @import 'gradient-theme'
 
@@ -127,7 +127,7 @@ button,
   max-width: 120px
   height: 40px
   border-radius: 20px
-  //transition: border 0.1s ease, background-color 0.1s ease
+
   border: 2px solid transparent
   display: flex
   justify-content: center
@@ -141,8 +141,6 @@ button,
   cursor: pointer
 
   &:hover
-    //border: 3px solid #4b4b4b
-    //background-color: #f9f9f9
     cursor: pointer
 
   &.average
@@ -1011,7 +1009,7 @@ button,
 
   #advancedFiltersPanel
     grid-area: filters
-    //display: block !important
+
     position: sticky
     top: 20px  // Stick to top when scrolling
     align-self: stretch  // Stretch to fill available height

--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -285,8 +285,21 @@ button,
     font-size: 9px
     color: #666
     
-  span
+  span, .count-value
     font-weight: 600
+    
+  // Smooth transition for count changes
+  .count-value
+    transition: all 0.2s ease
+    
+  // Visual feedback for filtered out benchmarks (count = 0)
+  &[style*="opacity: 0.5"]
+    background: #f5f5f5
+    color: #999
+    border-color: #ccc
+    
+    i, .count-value
+      color: #999
 
 .sort-indicator
   flex: 0 0 auto

--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -349,15 +349,6 @@ button,
   &:hover
     background-color: rgba(255, 255, 255, 0.08) !important  // Slightly different highlight for navigation
     
-// Sorting area (invisible overlay covering right 20%)
-.sorting-area
-  &:hover
-    background-color: rgba(255, 255, 255, 0.1) !important  // Subtle highlight on hover
-    
-  &:hover + .sort-indicator
-    transform: scale(1.2)
-    color: #000
-
 // Search bar and filter button wrapper
 #leaderboardSearchWrapper
   display: flex
@@ -382,11 +373,9 @@ button,
       border-color: #727272
 
 .ag-header-cell-resize
-  width: 8px !important // widen the resize handle
+  width: 0 !important // Disable resize handles
   background-color: transparent
   opacity: 0
-  width: 0
-  //width: 0 !important
 
 .ag-header-cell:hover .ag-header-cell-resize
   background-color: rgba(0, 0, 0, 0.1) // light gray on hover
@@ -400,9 +389,6 @@ button,
   border-radius: 6px
   background-color: #f9f9f9
 
-//.advanced-filters.hidden
-//  display: none
-
 .advanced-filters
   padding: 20px
   background: #f8f9fa
@@ -413,8 +399,6 @@ button,
   overflow: visible !important  // Allow dropdowns to overflow
   display: block
 
-  //&.hidden
-  //  display: none !important
 
   h3
     margin-top: 0

--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -1,4 +1,5 @@
 //@import "../../../node_modules/bulma/sass/utilities/mixins"
+@import '../variables'
 @import 'gradient-theme'
 
 // Base button styling (all buttons get basic styling)
@@ -145,22 +146,25 @@ button,
     cursor: pointer
 
   &.average
-    background-color: #9BE36D
-    color: black
+    background-color: $brainscore_green
+    color: $brainscore_gray4
     &:hover
-      background-color: lighten(#9BE36D, 10%)
+      background-color: lighten($brainscore_green, 10%)
   &.neural
-    background-color: #1F3157
+    background-color: $brainscore_gray4
+    color: $brainscore_green
     &:hover
-      background-color: lighten(#1F3157, 10%)
+      background-color: lighten($brainscore_gray4, 10%)
   &.behavior
-    background-color: #2E5739
+    background-color: $brainscore_gray4
+    color: $brainscore_green
     &:hover
-      background-color: lighten(#2E5739, 10%)
+      background-color: lighten($brainscore_gray4, 10%)
   &.engineering
-    background-color: #5C8DB8
+    background-color: $brainscore_sky
+    color: $brainscore_gray4
     &:hover
-      background-color: lighten(#5C8DB8, 10%)
+      background-color: lighten($brainscore_sky, 10%)
   &:not(.neural):not(.behavior):not(.engineering):not(.average)
     background-color: #d4d4d4
     color: black
@@ -181,6 +185,20 @@ button,
     display: inline-block
     max-width: 100%
 
+  &::after
+    content: ''
+    position: absolute
+    top: 0
+    right: 0
+    width: 20%
+    height: 100%
+    background: linear-gradient(270deg, rgba(255,255,255,0.05) 0%, rgba(255,255,255,0) 100%)
+    pointer-events: none
+    z-index: 1
+    
+  &:hover::after
+    background: linear-gradient(270deg, rgba(255,255,255,0.15) 0%, rgba(255,255,255,0) 100%)
+
 .leaf-header
   display: flex
   justify-content: center
@@ -192,6 +210,7 @@ button,
   min-width: 120px
   max-width: 120px
   cursor: pointer
+  position: relative  // Enable absolute positioning for click areas
 
   .leaf-header-label
     display: inline-block
@@ -201,24 +220,130 @@ button,
     white-space: nowrap
     font-weight: bold
     color: #333
+    pointer-events: none  // Prevent text selection conflicts
+
+  // Navigation hint gradient on left 80%
+  &::before
+    content: ''
+    position: absolute
+    top: 0
+    left: 0
+    width: 80%
+    height: 100%
+    background: linear-gradient(90deg, rgba(66, 133, 244, 0.03) 0%, rgba(66, 133, 244, 0) 100%)
+    pointer-events: none
+    z-index: 1
+    border-radius: 20px 0 0 20px
+    
+  &:hover::before
+    background: linear-gradient(90deg, rgba(66, 133, 244, 0.08) 0%, rgba(66, 133, 244, 0) 100%)
+
+  // Sorting hint gradient on right 20%  
+  &::after
+    content: ''
+    position: absolute
+    top: 0
+    right: 0
+    width: 20%
+    height: 100%
+    background: linear-gradient(270deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0) 100%)
+    pointer-events: none
+    z-index: 1
+    border-radius: 0 20px 20px 0
+    
+  &:hover::after
+    background: linear-gradient(270deg, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0) 100%)
 
 // Count badge inside header pill
 .benchmark-count
   position: absolute
-  bottom: -8px
+  bottom: -12px  // Moved lower for more space
   right: -5px
   background: white
   color: #333
-  font-size: 12px
+  font-size: 11px
   border: 1px solid #ddd
-  border-radius: 10px
-  padding: 0 6px
+  border-radius: 12px
+  padding: 2px 8px
+  cursor: pointer
+  transition: all 0.2s ease
+  z-index: 12  // Higher than sorting area
+  display: flex
+  align-items: center
+  gap: 3px
+  min-width: 20px
+  white-space: nowrap
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1)  // Add subtle shadow
 
-.expand-toggle
+  &:hover
+    background: #f0f0f0
+    border-color: #bbb
+    transform: scale(1.05)
+    box-shadow: 0 3px 6px rgba(0,0,0,0.15)
+
+  i
+    font-size: 9px
+    color: #666
+    
+  span
+    font-weight: 600
+
+.sort-indicator
   flex: 0 0 auto
-  margin-left: -4px  // visually nudge it closer
+  margin-left: 4px
   padding-right: 4px
-  z-index: 1
+  z-index: 11  // Higher than sorting area but lower than count badge
+  transition: all 0.2s ease
+  color: #666
+  font-weight: bold
+  font-size: 16px !important  // Global 16px size for all sort indicators
+  
+  // Default state (neutral sort icon)
+  &[style*="opacity: 0.5"], &[style*="opacity: 0.6"]
+    color: #999
+    font-weight: normal
+  
+  // Active state (sorted)
+  &[style*="opacity: 1"]
+    color: #333
+    font-weight: bold
+
+  &:hover
+    transform: scale(1.1)
+    color: #000
+
+// White sort indicators for neural and behavior headers (dark backgrounds)
+.expandable-header.neural .sort-indicator,
+.expandable-header.behavior .sort-indicator
+  color: white !important
+  
+  // Default state for dark backgrounds
+  &[style*="opacity: 0.5"], &[style*="opacity: 0.6"]
+    color: rgba(255, 255, 255, 0.6) !important
+    font-weight: normal
+  
+  // Active state for dark backgrounds
+  &[style*="opacity: 1"]
+    color: white !important
+    font-weight: bold
+
+  &:hover
+    transform: scale(1.1)
+    color: white !important
+
+// Navigation area (middle 60% for benchmark links)
+.navigation-area
+  &:hover
+    background-color: rgba(255, 255, 255, 0.08) !important  // Slightly different highlight for navigation
+    
+// Sorting area (invisible overlay covering right 20%)
+.sorting-area
+  &:hover
+    background-color: rgba(255, 255, 255, 0.1) !important  // Subtle highlight on hover
+    
+  &:hover + .sort-indicator
+    transform: scale(1.2)
+    color: #000
 
 // Search bar and filter button wrapper
 #leaderboardSearchWrapper

--- a/static/benchmarks/js/ag-grid-leaderboard.js
+++ b/static/benchmarks/js/ag-grid-leaderboard.js
@@ -1989,33 +1989,28 @@ function getAllDescendantsFromHierarchy(parentId, hierarchyMap) {
 // Shared utility to create and manage sort indicators
 function createSortIndicator(params, element, fontSize = '12px') {
   const indicator = document.createElement('span');
-  indicator.className = 'sort-indicator';
-  indicator.textContent = '━';
+  indicator.className = 'sort-indicator ag-icon';  // Use AG Grid icon classes
   indicator.style.cursor = 'pointer';
   indicator.style.marginLeft = '4px';
-  indicator.style.fontSize = fontSize;
-  indicator.style.opacity = '0.5';
-  indicator.style.textShadow = '0 0 2px rgba(255,255,255,0.8)';
+  indicator.style.fontSize = '16px';  // AG Grid default icon size
+  indicator.style.opacity = '0.87';  // AG Grid's default icon opacity
   
   const updateSortIndicator = () => {
     const column = params.column;
     const currentSort = column.getSort();
     
+    // Remove all AG Grid sort icon classes
+    indicator.classList.remove('ag-icon-asc', 'ag-icon-desc', 'ag-icon-none');
+    
     if (currentSort === 'asc') {
-      indicator.textContent = '↑';
+      indicator.classList.add('ag-icon-asc');
       indicator.style.opacity = '1';
-      indicator.style.color = '#333';
-      indicator.style.textShadow = '0 0 3px rgba(255,255,255,0.9)';
     } else if (currentSort === 'desc') {
-      indicator.textContent = '↓';
+      indicator.classList.add('ag-icon-desc');
       indicator.style.opacity = '1';
-      indicator.style.color = '#333';
-      indicator.style.textShadow = '0 0 3px rgba(255,255,255,0.9)';
     } else {
-      indicator.textContent = '━';
-      indicator.style.opacity = '0.6';
-      indicator.style.color = '#333';
-      indicator.style.textShadow = '0 0 2px rgba(255,255,255,0.8)';
+      indicator.classList.add('ag-icon-none');
+      indicator.style.opacity = '0.54';  // AG Grid's opacity for inactive icons
     }
   };
 

--- a/static/benchmarks/js/ag-grid-leaderboard.js
+++ b/static/benchmarks/js/ag-grid-leaderboard.js
@@ -152,7 +152,7 @@ LeafHeaderComponent.prototype.init = function(params) {
     const column = params.column;
     const colId = column.getColId();
     const currentSort = column.getSort();
-    const nextSort = currentSort === 'asc' ? 'desc' : (currentSort === 'desc' ? null : 'asc');
+    const nextSort = currentSort === 'desc' ? 'asc' : (currentSort === 'asc' ? null : 'desc');
 
     if (params.api && typeof params.api.applyColumnState === 'function') {
       params.api.applyColumnState({
@@ -509,7 +509,7 @@ ExpandableHeaderComponent.prototype.init = function(params) {
       const column = params.column;
       const colId = column.getColId();
       const currentSort = column.getSort();
-      const nextSort = currentSort === 'asc' ? 'desc' : (currentSort === 'desc' ? null : 'asc');
+      const nextSort = currentSort === 'desc' ? 'asc' : (currentSort === 'asc' ? null : 'desc');
 
       if (params.api && typeof params.api.applyColumnState === 'function') {
         params.api.applyColumnState({
@@ -585,7 +585,7 @@ ExpandableHeaderComponent.prototype.init = function(params) {
       const column = params.column;
       const colId = column.getColId();
       const currentSort = column.getSort();
-      const nextSort = currentSort === 'asc' ? 'desc' : (currentSort === 'desc' ? null : 'asc');
+      const nextSort = currentSort === 'desc' ? 'asc' : (currentSort === 'asc' ? null : 'desc');
 
       if (params.api && typeof params.api.applyColumnState === 'function') {
         params.api.applyColumnState({
@@ -2412,9 +2412,11 @@ function initializeGrid(rowData, columnDefs, benchmarkGroups) {
       leafComponent: LeafHeaderComponent,
     },
     suppressFieldDotNotation: true,
+    sortingOrder: ['desc', 'asc', null],  // Sort cycle: desc -> asc -> none
     defaultColDef: {
       sortable: true,
       resizable: false,
+      unSortIcon: true,  // Show unsort icon for 3-state sorting
       valueFormatter: params => {
         const v = params.value;
         return (v != null && typeof v === 'object' && 'value' in v)


### PR DESCRIPTION
Uses #398 as base.

## Features
- Update the leaderboard header to match previous leaderboard's aesthetic. 
- Made benchmark expand functionality triggered by "benchmark children" bubble. Added expand and collapse arrows like original leaderboard.
- Parent benchmark sort by triggered by full header. Child benchmark sort by triggered by sort by icon.
- Made AG-Grid's headers (i.e., rank, model, filtered score) sort by and custom headers (i.e., benchmark headers) sort by the same style for consistency. 
- Introduce benchmark card hyperlink to leaf benchmark headers
    - Since parent benchmarks are abstract and do not have a benchmark card to link to, the entire header will trigger sort by functionality. Leaf benchmarks are actual benchmarks and therefore have a benchmark card to link to. As such, the header redirects to benchmark card and sort by functionality requires clicking on the sort by icon. **This design choice minimizes differences in functionality pre- and post-AG grid refactor.**
- Force order to sort by from ascending>descending>null to descending>ascending>null

## Demo
### Before this change

https://github.com/user-attachments/assets/0d237691-743e-4a2f-b10e-8dd78b890065

### After this change

https://github.com/user-attachments/assets/5416b526-3fe2-4c13-84fb-be25dfa4eb20

## Notes for production-ready refactor
- Should refactor both the `ag-grid-leaderboard.js` and `ag-grid-leaderboard.sass` into more modular components. Number of children/descendent functionality can be reused. Sort by bubble can be reused.