### PR TITLE
Add model runnable status icon to leaderboard

### DIFF
--- a/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
+++ b/static/benchmarks/css/leaderboard/ag-grid-leaderboard.sass
@@ -98,6 +98,41 @@ button,
     color: #666
     font-style: italic
 
+// Runnable status cell
+.ag-cell[col-id="runnable_status"]
+  display: flex
+  justify-content: center
+  align-items: center
+  height: 100%
+
+.runnable-status-cell
+  display: flex
+  justify-content: center
+  align-items: center
+  height: 100%
+
+.runnable-status-icon
+  width: 12px
+  height: 12px
+  border-radius: 50%
+  cursor: help
+  position: relative
+  z-index: 1
+  
+  &.runnable-green
+    background-color: #28a745
+  
+  &.runnable-red
+    background-color: #dc3545
+  
+  &.runnable-grey
+    background-color: #6c757d
+
+// Ensure tooltips work properly
+.runnable-status-cell,
+.runnable-status-icon
+  pointer-events: auto
+
 // Score pill container
 .score-pill-container
   display: flex

--- a/static/benchmarks/js/ag-grid-leaderboard.js
+++ b/static/benchmarks/js/ag-grid-leaderboard.js
@@ -20,6 +20,10 @@ window.activeFilters = {
 // Global state for tracking column expansion
 window.columnExpansionState = new Map();
 
+// =====================================
+// CELL RENDERERS
+// =====================================
+
 // ModelCellRenderer
 function ModelCellRenderer() {}
 ModelCellRenderer.prototype.init = function(params) {
@@ -41,6 +45,66 @@ ModelCellRenderer.prototype.init = function(params) {
 ModelCellRenderer.prototype.getGui = function() {
   return this.eGui;
 };
+
+// =====================================
+// RUNNABLE STATUS FUNCTIONALITY
+// =====================================
+// This section handles the display of model code runnable status as colored
+// circles in a dedicated Status column with tooltips explaining the status.
+// Green = functional, Red = issues, Grey = unknown
+
+// RunnableStatusCellRenderer - displays colored status circles with tooltips
+function RunnableStatusCellRenderer() {}
+RunnableStatusCellRenderer.prototype.init = function(params) {
+  this.eGui = document.createElement('div');
+  this.eGui.className = 'runnable-status-cell';
+  
+  const runnable = params.data?.metadata?.runnable;
+  const statusIcon = document.createElement('div');
+  statusIcon.className = 'runnable-status-icon';
+  
+  if (runnable === true) {
+    statusIcon.classList.add('runnable-green');
+  } else if (runnable === false) {
+    statusIcon.classList.add('runnable-red');
+  } else {
+    statusIcon.classList.add('runnable-grey');
+  }
+  
+  this.eGui.appendChild(statusIcon);
+};
+RunnableStatusCellRenderer.prototype.getGui = function() {
+  return this.eGui;
+};
+
+// Helper function to create runnable status column definition
+function createRunnableStatusColumn() {
+  return {
+    headerName: 'Status',
+    field: 'runnable_status',
+    colId: 'runnable_status',
+    pinned: 'left',
+    width: 80,
+    cellRenderer: 'runnableStatusCellRenderer',
+    sortable: true,
+    filter: false,
+    headerClass: 'centered-header',
+    valueGetter: params => {
+      const runnable = params.data?.metadata?.runnable;
+      return runnable === true ? 2 : runnable === false ? 1 : 0; // For sorting: green > red > grey
+    },
+    tooltipValueGetter: params => {
+      const runnable = params.data?.metadata?.runnable;
+      if (runnable === true) {
+        return 'Model code is functional and runnable';
+      } else if (runnable === false) {
+        return 'Model code has known issues or is non-functional';
+      } else {
+        return 'Model code status unknown';
+      }
+    }
+  };
+}
 
 // Model Comparator for sorting models by name
 function modelComparator(a, b) {
@@ -2069,6 +2133,9 @@ function initializeGrid(rowData, columnDefs, benchmarkGroups) {
     }
   });
 
+  // Add the runnable status column
+  const runnableStatusColumn = createRunnableStatusColumn();
+
   // Add the filtered score column
   const filteredScoreColumn = {
     headerName: 'Filtered Score',
@@ -2102,12 +2169,12 @@ function initializeGrid(rowData, columnDefs, benchmarkGroups) {
     }
   };
 
-  // Insert filtered score column after the model column
+  // Insert columns after the model column
   const modelColumnIndex = columnDefs.findIndex(col => col.field === 'model');
   if (modelColumnIndex !== -1) {
-    columnDefs.splice(modelColumnIndex + 1, 0, filteredScoreColumn);
+    columnDefs.splice(modelColumnIndex + 1, 0, runnableStatusColumn, filteredScoreColumn);
   } else {
-    columnDefs.push(filteredScoreColumn);
+    columnDefs.push(runnableStatusColumn, filteredScoreColumn);
   }
 
   const gridOptions = {
@@ -2115,9 +2182,16 @@ function initializeGrid(rowData, columnDefs, benchmarkGroups) {
     columnDefs,
     headerHeight: 60,
     rowHeight: 60,
+    tooltipShowDelay: 500, // Show tooltip after 0.5 seconds
     components: {
+      // Core cell renderers
       modelCellRenderer: ModelCellRenderer,
       scoreCellRenderer: ScoreCellRenderer,
+      
+      // Runnable status functionality
+      runnableStatusCellRenderer: RunnableStatusCellRenderer,
+      
+      // Header components
       expandableHeaderComponent: ExpandableHeaderComponent,
       leafComponent: LeafHeaderComponent,
     },
@@ -2142,6 +2216,7 @@ function initializeGrid(rowData, columnDefs, benchmarkGroups) {
       // Ensure filtered score column starts hidden (clean initial state)
       params.api.applyColumnState({
         state: [
+          { colId: 'runnable_status', hide: false },
           { colId: 'filtered_score', hide: true },
           { colId: 'average_vision_v0', hide: false }
         ]
@@ -2274,8 +2349,8 @@ function updateColumnVisibility() {
   allColumns.forEach(column => {
     const colId = column.getColId();
     
-    // Skip non-benchmark columns
-    if (['model', 'rank', 'filtered_score', 'average_vision_v0'].includes(colId)) {
+    // Skip non-benchmark columns (including runnable status)
+    if (['model', 'rank', 'runnable_status', 'filtered_score', 'average_vision_v0'].includes(colId)) {
       return;
     }
     
@@ -2308,8 +2383,8 @@ function setInitialColumnState() {
   allColumns.forEach(column => {
     const colId = column.getColId();
     
-    // Always show these columns
-    if (['model', 'rank', 'filtered_score'].includes(colId)) {
+    // Always show these columns (including runnable status)
+    if (['model', 'rank', 'runnable_status', 'filtered_score'].includes(colId)) {
       initialColumnState.push({ colId: colId, hide: false });
       return;
     }


### PR DESCRIPTION
Uses #398 as base.

## Description
Simple PR that adds the runnable metadata as a column called `Status`. If preferred, we can combine it with the model name column if a dedicated column is taking too much space.

Green status = model has been tested and runs
Red status = model has been tested and does not run
Gray status = model has not been tested so status unknown

## Demo

https://github.com/user-attachments/assets/fb91521c-0af9-4e28-9fe0-0d3b34ed02df


