### PR TITLE
Fix various benchmark card related issues

### DIFF
--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -398,7 +398,15 @@ def representative_color(value, min_value=None, max_value=None, colors=colors_re
         return f"background-color: {color_None}"
     if np.isnan(value):
         return f"background-color: {color_None}"
+    # Check if min_value or max_value is NaN, which would cause normalize_value to return NaN
+    if min_value is not None and np.isnan(min_value):
+        return f"background-color: {color_None}"
+    if max_value is not None and np.isnan(max_value):
+        return f"background-color: {color_None}"
     normalized_value = normalize_value(value, min_value=min_value, max_value=max_value)  # normalize to range
+    # Additional safety check in case normalized_value is NaN
+    if np.isnan(normalized_value):
+        return f"background-color: {color_None}"
     step = int(100 * normalized_value)
     try:
         color = colors[step]


### PR DESCRIPTION
There have been a number of long standing benchmark card related issues described in a few issues. This PR resolves them all.


### Server Error for Kar2019-ost benchmark card (#420, #376 )

**Problem:** NaN values in scores weren't properly handled in color calculation and score ordering.

**Solution:** Check for NaN, use different function to exclude NaN from calculation, and use Python sorting instead of database sorting to properly handle NaN values. Add some safety checks to prevent NaNs throwing issues in the future.

<img width="2168" height="1328" alt="image" src="https://github.com/user-attachments/assets/146e4564-d200-4c57-9525-501aeccc1080" />


### Score values missing on engineering benchmark cards (#372 )

**Problem:** Engineering benchmark cards displayed empty/no score values because benchmark card was using score_ceiled as primary value but engineering uses score_raw.

**Solution:** Check database if benchmark has root engineering. If so, use score_raw instead of score_ceiled.

<img width="2168" height="1328" alt="image" src="https://github.com/user-attachments/assets/c5ccd560-c6a0-4519-95a8-a1b1719fb30a" />
