### PR TITLE
Recursively collapse benchmarks in model card page

### DIFF
--- a/static/benchmarks/js/collapsible.js
+++ b/static/benchmarks/js/collapsible.js
@@ -24,11 +24,6 @@ $(document).ready(function () {
                 Array.from(targets).forEach((target) => {
                     switch_state(target, control);
                 });
-                
-                // Only apply recursive hiding after initial setup and for user interactions
-                if (isCollapsing && !isInitialSetup) {
-                    recursivelyHideDescendants(identifier);
-                }
             }
         };
 

--- a/static/benchmarks/js/collapsible.js
+++ b/static/benchmarks/js/collapsible.js
@@ -1,4 +1,6 @@
 $(document).ready(function () {
+    let isInitialSetup = true;
+    
     const collapsible_controls = document.getElementsByClassName("collapsible_control");
     Array.from(collapsible_controls).forEach((control) => {
         control.onclick = function () {
@@ -12,9 +14,21 @@ $(document).ready(function () {
             else {
                 const identifier = control.getAttribute('data-identifier');
                 const targets = document.querySelectorAll(`[data-parent=${CSS.escape(identifier)}]`);
+                
+                // Check if we're about to hide children (for recursive collapsing)
+                let isCollapsing = false;
+                if (targets.length > 0) {
+                    isCollapsing = targets[0].style.display !== "none";
+                }
+                
                 Array.from(targets).forEach((target) => {
                     switch_state(target, control);
-                })
+                });
+                
+                // Only apply recursive hiding after initial setup and for user interactions
+                if (isCollapsing && !isInitialSetup) {
+                    recursivelyHideDescendants(identifier);
+                }
             }
         };
 
@@ -23,6 +37,11 @@ $(document).ready(function () {
             control.click();
         }
     });
+    
+    // After initial setup is complete, enable recursive behavior for user interactions
+    setTimeout(() => {
+        isInitialSetup = false;
+    }, 100);
 });
 
 function switch_state(target, control) {
@@ -36,4 +55,32 @@ function switch_state(target, control) {
         control.className = control.className.replace(
             "is_collapsible", "is_expandable"); // switch symbol
     }
+}
+
+function recursivelyHideDescendants(parentId) {
+    // Find all divs that are children of this parent
+    const childDivs = document.querySelectorAll(`div[data-parent="${CSS.escape(parentId)}"]`);
+    
+    childDivs.forEach((childDiv) => {
+        // Look for collapsible controls within this child
+        const childControl = childDiv.querySelector('.collapsible_control[data-identifier]');
+        
+        if (childControl) {
+            const childId = childControl.getAttribute('data-identifier');
+            
+            // Force hide all grandchildren
+            const grandChildren = document.querySelectorAll(`[data-parent="${CSS.escape(childId)}"]`);
+            grandChildren.forEach((grandChild) => {
+                grandChild.style.display = "none";
+            });
+            
+            // Set the child control to collapsed state
+            if (childControl.className.includes("is_collapsible")) {
+                childControl.className = childControl.className.replace("is_collapsible", "is_expandable");
+            }
+            
+            // Recursively handle this child's descendants
+            recursivelyHideDescendants(childId);
+        }
+    });
 }

--- a/static/benchmarks/js/collapsible.js
+++ b/static/benchmarks/js/collapsible.js
@@ -24,6 +24,11 @@ $(document).ready(function () {
                 Array.from(targets).forEach((target) => {
                     switch_state(target, control);
                 });
+                
+                // Only apply recursive hiding after initial setup and for user interactions
+                if (isCollapsing && !isInitialSetup) {
+                    recursivelyHideDescendants(identifier);
+                }
             }
         };
 


### PR DESCRIPTION
Long standing issue on the model card page where collapsing a parent does not collapse descendants and only the direct children. See #227 for more information.

**Problem:** The original implementation was that `collapsible.js` only handled direct parent-child relationships.

**Solution:** Introduced `recursivelyHideDescendants(parentId)` that recursively finds all descendants and hides them. Also introduced `isInitialSetup` timing logic to make sure page loads and then allow recursive hiding.