### PR TITLE
Hotfix: Fix broken nav bar links from /profile/

### DIFF
--- a/benchmarks/tests/test_views.py
+++ b/benchmarks/tests/test_views.py
@@ -74,12 +74,12 @@ class TestWebsitePages(BaseTestCase):
 
     def test_explore_page(self):
         """Test the explore page loads"""
-        response = self.client.get('/explore')
+        response = self.client.get('/vision/explore')
         self.assertEqual(response.status_code, 200)
 
     def test_compare_page(self):
         """Test the compare page loads"""
-        response = self.client.get('/compare')
+        response = self.client.get('/vision/compare')
         self.assertEqual(response.status_code, 200)
 
     def test_tutorials_home(self):

--- a/benchmarks/tests/test_views.py
+++ b/benchmarks/tests/test_views.py
@@ -74,12 +74,12 @@ class TestWebsitePages(BaseTestCase):
 
     def test_explore_page(self):
         """Test the explore page loads"""
-        response = self.client.get('/vision/explore')
+        response = self.client.get('/vision/explore/')
         self.assertEqual(response.status_code, 200)
 
     def test_compare_page(self):
         """Test the compare page loads"""
-        response = self.client.get('/vision/compare')
+        response = self.client.get('/vision/compare/')
         self.assertEqual(response.status_code, 200)
 
     def test_tutorials_home(self):

--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -1,6 +1,7 @@
 from functools import partial
 from django.conf import settings
 from django.urls import path
+from django.views.generic import RedirectView
 from .views import index, user, model, competition2022, competition2024, compare, community, release2_0, brain_model, \
     content_utils, benchmark, explore, leaderboard, report_issue
 from .utils import show_token, refresh_cache
@@ -14,9 +15,10 @@ non_domain_urls = [
     path('', user.LandingPage.as_view(), name='landing_page'),
     path('/', user.LandingPage.as_view(), name='landing_page'),
 
-    # global pages
-    path('explore', partial(explore.view, domain="vision"), name='explore'),
-    path('compare', partial(compare.view, domain="vision"), name='compare'),
+    # global pages - default to vision domain
+    path('explore/', RedirectView.as_view(url='/vision/explore/', permanent=False), name='default-explore'),
+    path('compare/', RedirectView.as_view(url='/vision/compare/', permanent=False), name='default-compare'),
+    path('leaderboard/', RedirectView.as_view(url='/vision/leaderboard/', permanent=False), name='default-leaderboard'),
     path('sponsors/', user.Sponsors.as_view(), name='sponsors'),
     path('faq/', user.Faq.as_view(), name='faq'),
     path('community', partial(community.view), name='community'),
@@ -35,10 +37,6 @@ non_domain_urls = [
     # central profile page, constant across all Brain-Score domains
     path('profile/', user.ProfileAccount.as_view(), name='default-profile'),
     path('profile/public-ajax/', user.PublicAjax.as_view(), name='PublicAjax'),
-
-    # need navbar links when on /profile. Default to vision.
-    # this is a **temporary** fix until the new UI landing page is live.
-    path('profile/', user.Profile.as_view(domain="vision"), name='default-profile-navbar'),
     path('profile/submit/', user.Upload.as_view(domain="vision"), name=f'vision-submit'),
     path('profile/resubmit/', partial(user.resubmit, domain="vision"), name='vision-resubmit'),
     path('profile/logout/', user.Logout.as_view(domain="vision"), name='vision-logout'),

--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -652,7 +652,8 @@ class ProfileAccount(View):
                 "domains": ["vision", "language"],
                 "files_submitted": files_submitted,
                 "total_used_gb": round(total_size_used / 1024**3, 3),
-                'quota_gb': 5.0}
+                'quota_gb': 5.0,
+                "domain": "vision"}  # Default domain for navigation links
             return render(request, 'benchmarks/central_profile.html', context)
 
     def post(self, request):


### PR DESCRIPTION
Addresses #440

Redirects to `/vision/{page}` by default unless on `/profile/{domain}` when then directs to `/{domain}/{page}` 