### PR TITLE
Remove cache_page decorator

### DIFF
--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -39,9 +39,6 @@ def get_base_model_query(domain="vision"):
     """Get the base model query for a domain before any filtering"""
     return FinalModelContext.objects.filter(domain=domain)  # Return QuerySet instead of list
 
-# Cache the leaderboard HTML page
-# Server-side HTML caching until leaderboard views are introduced.
-#@cache_page(7 * 24 * 60 * 60, key_prefix="cache_page")
 def view(request, domain: str):
     # Get the authenticated user if any
     user = request.user if request.user.is_authenticated else None

--- a/benchmarks/views/leaderboard.py
+++ b/benchmarks/views/leaderboard.py
@@ -532,7 +532,6 @@ def ag_grid_leaderboard_shell(request, domain: str):
     }
     return render(request, 'benchmarks/leaderboard/ag-grid-leaderboard-shell.html', context)
 
-#@cache_page(7 * 24 * 60 * 60, key_prefix="cache_page")
 def ag_grid_leaderboard_content(request, domain: str):
     """
     Heavy content view that returns just the leaderboard content via AJAX


### PR DESCRIPTION
Cache page decorator was causing a cache conflict in the profile leaderboard view because the key does not store user-id. 

We no longer need this decorator because we first load the shell and then load data via AJAX.