### PR TITLE
remove bad main.css calls

### DIFF
--- a/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard-content.html
+++ b/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard-content.html
@@ -2,8 +2,7 @@
 
 <!-- This template contains just the heavy leaderboard content -->
 
-<!-- Ensure CSS is loaded in content template -->
-<link rel="stylesheet" href="{% static 'benchmarks/css/main.css' %}">
+<!-- CSS is loaded by the base template -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/driver.js@1.3.1/dist/driver.css">
 <div class="leaderboard-header">
   <!-- banner & icon… -->

--- a/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard-shell.html
+++ b/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard-shell.html
@@ -6,7 +6,6 @@
         href="https://cdn.jsdelivr.net/npm/ag-grid-community@33.2.4/styles/ag-grid.css">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/ag-grid-community@33.2.4/styles/ag-theme-alpine.css">
-  <link rel="stylesheet" href="{% static 'benchmarks/css/main.css' %}">
 {% endblock %}
 
 {% block banner %}

--- a/benchmarks/templates/benchmarks/profile.html
+++ b/benchmarks/templates/benchmarks/profile.html
@@ -6,7 +6,6 @@
         href="https://cdn.jsdelivr.net/npm/ag-grid-community@33.2.4/styles/ag-grid.css">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/ag-grid-community@33.2.4/styles/ag-theme-alpine.css">
-  <link rel="stylesheet" href="{% static 'benchmarks/css/main.css' %}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/driver.js@latest/dist/driver.css"/>
 {% endblock %}
 


### PR DESCRIPTION
### Fix 404 errors for main.css on profile and leaderboard pages
Removed redundant references to main.css from profile and AG-Grid leaderboard templates that were causing 404 errors. The main CSS is already properly loaded through Django Compressor in the base template, which generates hashed CSS files.

This resolves console 404 errors that were interfering with Canary monitoring systems while maintaining all existing styling functionality.