### PR TITLE
remove cache decorator for compare page

### DIFF
--- a/benchmarks/views/compare.py
+++ b/benchmarks/views/compare.py
@@ -4,7 +4,6 @@ from django.views.decorators.cache import cache_page
 
 from .index import get_context
 
-@cache_page(24 * 60 * 60)
 def view(request, domain: str):
     context = get_context(show_public=True, domain=domain)
 


### PR DESCRIPTION
Removes the compare page caching decorator, similar to #461.  Web canaries picked up failed styling on compare, and this seems to be the cause. 