### PR TITLE
Fix font awesome CSS loading

### DIFF
--- a/benchmarks/templates/benchmarks/base.html
+++ b/benchmarks/templates/benchmarks/base.html
@@ -37,7 +37,7 @@
     {% endcompress %}
 
     {# libraries #}
-    <script defer src="https://kit.fontawesome.com/2180d98b9d.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script defer src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script defer src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
     <script defer src="https://labratrevenge.com/d3-tip/javascripts/d3.tip.v0.6.3.js"></script>


### PR DESCRIPTION
Unclear when the `kit.fontawesome/js` script broke but it no longer works. Returns forbidden.

Leaderboard Content page was loading FA icons through a different link, which works, but was conflicting with the `base.html` preventing them from being loaded globally. Have added the working link to `base.html`.

# Before
<img width="1160" height="217" alt="image" src="https://github.com/user-attachments/assets/3d8467ae-edd3-4dde-9fef-926d955e6630" />

<img width="393" height="452" alt="image" src="https://github.com/user-attachments/assets/8d5ae787-e921-435e-85e1-43f5a63fd791" />


# After
<img width="842" height="209" alt="image" src="https://github.com/user-attachments/assets/c97003f6-a3d9-4ba6-b58e-17b7b27ebf87" />

<img width="548" height="405" alt="image" src="https://github.com/user-attachments/assets/64a5630b-b114-4e8e-ab49-69baf61fa125" />
