### PR TITLE
Wayback Slider Working Version

### DIFF
--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -273,8 +273,8 @@ class Score(models.Model):
     score_raw = models.FloatField(default=0, null=True)
     score_ceiled = models.FloatField(default=0, null=True)
     error = models.FloatField(default=0, null=True)
-    start_timestamp = models.DateTimeField(blank=True)
-    end_timestamp = models.DateTimeField(auto_now_add=True, blank=True, null=True)
+    start_timestamp = models.DateTimeField(null=True, blank=True)
+    end_timestamp = models.DateTimeField(null=True, blank=True)
     comment = models.CharField(max_length=1000, null=True)
 
     def __repr__(self):

--- a/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard-content.html
+++ b/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard-content.html
@@ -28,11 +28,11 @@
       <span class="text-wrapper">Advanced Filters</span>
     </button>
   {% endif %}
-  
+
   <button id="exportCsvButton" class="btn-secondary" style="background-color: #47B7DE; color: white; border: none; white-space: nowrap" title="Export leaderboard data and plugin metadata">
     <i class="fa-solid fa-download"></i>  Export
   </button>
-  
+
   {% if domain == "vision" %}
   <button id="tutorialBtn" style="margin-left: 8px;" title="Interactive walkthrough of the leaderboard">
     <i class="fa-solid fa-info"></i>
@@ -206,6 +206,27 @@
               <div class="slider-range"></div>
               <div class="slider-handle handle-min" data-value="0"></div>
               <div class="slider-handle handle-max" data-value="1000"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Wayback Timestamp Section -->
+      <div class="metadata-section" id="waybackTimestampSection" style="display: none;">
+        <div class="filter-group" id="waybackTimestampFilter">
+          <div class="filter-header">
+            <label>Wayback Timestamp</label>
+            <div class="range-values">
+              <input type="date" class="range-input-min" id="waybackDateMin">
+              <span class="range-separator">to</span>
+              <input type="date" class="range-input-max" id="waybackDateMax">
+            </div>
+          </div>
+          <div class="range-filter dual-handle">
+            <div class="slider-container" data-min="0" data-max="2000000000">
+              <div class="slider-track"></div>
+              <div class="slider-range"></div>
+              <div class="slider-handle handle-min" data-value="0"></div>
+              <div class="slider-handle handle-max" data-value="2000000000"></div>
             </div>
           </div>
         </div>

--- a/benchmarks/views/index.py
+++ b/benchmarks/views/index.py
@@ -14,6 +14,7 @@ from django.views.decorators.cache import cache_page
 
 from benchmarks.models import Score, FinalBenchmarkContext, FinalModelContext, Reference
 from ..utils import cache_get_context
+from datetime import datetime
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +34,23 @@ colors_gray = [colors_gray[int(a * np.power(i, b))] for i in range(len(colors_gr
 color_suffix = '_color'
 color_None = '#e0e1e2'
 
-
+def get_datetime_range(models):
+    """Extract min and max timestamps from model scores."""
+    timestamps = []
+    for model in models:
+        for score in (model.scores or []):
+            ts = score.get("end_timestamp")
+            if ts:
+                try:
+                    timestamps.append(datetime.fromisoformat(ts))
+                except Exception:
+                    pass  # Ignore malformed timestamps
+    if timestamps:
+        return {
+            "min": min(timestamps).isoformat(),
+            "max": max(timestamps).isoformat(),
+        }
+    return None
 
 def get_base_model_query(domain="vision"):
     """Get the base model query for a domain before any filtering"""

--- a/static/benchmarks/js/leaderboard/core/template-initialization.js
+++ b/static/benchmarks/js/leaderboard/core/template-initialization.js
@@ -2,11 +2,11 @@
 // This handles Django data parsing and initial setup
 
 function initializeLeaderboardFromTemplate() {
-  
+
   try {
     // Parse data from Django
     let rowData, columnDefs, benchmarkGroups, benchmarkTree, filterOptions;
-    
+
     try {
       rowData = JSON.parse(window.DJANGO_DATA.row_data);
       columnDefs = JSON.parse(window.DJANGO_DATA.column_defs);
@@ -38,20 +38,20 @@ function initializeLeaderboardFromTemplate() {
       }
       return; // Stop if data parsing fails
     }
-    
+
     // Clear URL parameters for language domain to ensure clean state
     const domain = window.DJANGO_DATA?.domain || 'vision';
     if (domain === 'language' && window.location.search) {
       const newURL = window.location.pathname;
       window.history.replaceState({}, '', newURL);
     }
-    
+
     // Make data globally available
     window.benchmarkTree = benchmarkTree;
     window.originalRowData = rowData;
     window.filterOptions = filterOptions;
     window.benchmarkMetadata = benchmarkMetadata;
-    
+
     window.benchmarkIds = benchmarkIds;
     window.benchmarkStimuliMetaMap = JSON.parse(window.DJANGO_DATA.benchmarkStimuliMetaMap);
     window.benchmarkDataMetaMap = JSON.parse(window.DJANGO_DATA.benchmarkDataMetaMap);
@@ -70,7 +70,7 @@ function initializeLeaderboardFromTemplate() {
         paramCountMax.max = ranges.parameter_ranges.max;
         paramCountMax.value = ranges.parameter_ranges.max;
       }
-      
+
       // Update slider container data attributes
       if (paramCountMin) {
         const paramSliderContainer = paramCountMin.closest('.filter-group')?.querySelector('.slider-container');
@@ -91,7 +91,7 @@ function initializeLeaderboardFromTemplate() {
         modelSizeMax.max = ranges.size_ranges.max;
         modelSizeMax.value = ranges.size_ranges.max;
       }
-      
+
       // Update slider container data attributes
       if (modelSizeMin) {
         const modelSizeSliderContainer = modelSizeMin.closest('.filter-group')?.querySelector('.slider-container');
@@ -112,7 +112,7 @@ function initializeLeaderboardFromTemplate() {
         stimuliCountMax.max = ranges.stimuli_ranges.max;
         stimuliCountMax.value = ranges.stimuli_ranges.max;
       }
-      
+
       // Update slider container data attributes
       if (stimuliCountMin) {
         const stimuliSliderContainer = stimuliCountMin.closest('.filter-group')?.querySelector('.slider-container');
@@ -125,21 +125,58 @@ function initializeLeaderboardFromTemplate() {
         }
       }
     }
-    
+    // Initialize wayback timestamp filter if datetime_range data is available
+    if (ranges.datetime_range?.min_unix && ranges.datetime_range?.max_unix) {
+      const waybackSection = document.getElementById('waybackTimestampSection');
+      const waybackSliderContainer = document.querySelector('#waybackTimestampFilter .slider-container');
+      const waybackDateMin = document.getElementById('waybackDateMin');
+      const waybackDateMax = document.getElementById('waybackDateMax');
+
+      if (waybackSection && waybackSliderContainer && waybackDateMin && waybackDateMax) {
+        // Show the wayback section
+        waybackSection.style.display = 'block';
+
+        // Set slider range using Unix timestamps
+        waybackSliderContainer.dataset.min = ranges.datetime_range.min_unix;
+        waybackSliderContainer.dataset.max = ranges.datetime_range.max_unix;
+
+        // Set initial handle positions
+        const minHandle = waybackSliderContainer.querySelector('.handle-min');
+        const maxHandle = waybackSliderContainer.querySelector('.handle-max');
+        if (minHandle && maxHandle) {
+          minHandle.dataset.value = ranges.datetime_range.min_unix;
+          maxHandle.dataset.value = ranges.datetime_range.max_unix;
+        }
+
+        // Set date input values
+        const minDate = new Date(ranges.datetime_range.min_unix * 1000);
+        const maxDate = new Date(ranges.datetime_range.max_unix * 1000);
+        waybackDateMin.value = minDate.toISOString().split('T')[0];
+        waybackDateMax.value = maxDate.toISOString().split('T')[0];
+
+        console.log('Wayback timestamp filter initialized:', {
+          min_unix: ranges.datetime_range.min_unix,
+          max_unix: ranges.datetime_range.max_unix,
+          min_date: waybackDateMin.value,
+          max_date: waybackDateMax.value
+        });
+      }
+    }
+
     // Initialize grid
     if (typeof initializeGrid === 'function') {
       initializeGrid(rowData, columnDefs, benchmarkGroups);
     }
-    
+
     setupUIComponents();
     setupFilters();
     setupEventHandlers();
-    
+
     // Setup report issue functionality
     if (typeof window.LeaderboardReportIssue?.setupReportIssue === 'function') {
       window.LeaderboardReportIssue.setupReportIssue();
     }
-    
+
   } catch (error) {
     console.error('Error during grid initialization:', error);
     // Hide loading animation on error
@@ -156,28 +193,28 @@ function setupUIComponents() {
   const container = document.querySelector('.leaderboard-container');
   const advancedFilterBtn = document.getElementById('advancedFilterBtn');
   const layoutToggleBtn = document.getElementById('toggleLayoutBtn');
-  
+
   // Render benchmark tree (only if elements exist - they don't exist for language domain)
   if (typeof renderBenchmarkTree === 'function' && treeContainer) {
     renderBenchmarkTree(treeContainer, window.benchmarkTree);
   }
-  
+
   if (typeof populateFilterDropdowns === 'function') {
     populateFilterDropdowns(window.filterOptions);
   }
-  
+
   if (typeof setupDropdownHandlers === 'function') {
     setupDropdownHandlers();
   }
-  
+
   if (typeof setupBenchmarkCheckboxes === 'function') {
     setupBenchmarkCheckboxes(window.filterOptions);
   }
-  
+
   setTimeout(() => {
     initializeDualHandleSliders();
   }, 10);
-  
+
   // Initial badge count update
   setTimeout(() => {
     if (typeof window.updateAllCountBadges === 'function') {
@@ -195,12 +232,12 @@ function setupFilters() {
                                    urlParams.has('benchmark_tasks') ||
                                    urlParams.has('public_data_only') ||
                                    urlParams.has('excluded_benchmarks');
-  
+
     // Parse URL filters first (this will set checkbox states if URL params exist)
     if (typeof parseURLFilters === 'function') {
       parseURLFilters();
     }
-    
+
     // Always rebuild exclusion set based on current checkbox states
     window.filteredOutBenchmarks = new Set();
     const allCheckboxes = document.querySelectorAll('#benchmarkFilterPanel input[type="checkbox"]');
@@ -209,7 +246,7 @@ function setupFilters() {
         window.filteredOutBenchmarks.add(cb.value);
       }
     });
-  
+
     console.log('Excluded benchmarks after initialization:', [...window.filteredOutBenchmarks]);
   }, 20);
 }
@@ -217,41 +254,41 @@ function setupFilters() {
 function setupEventHandlers() {
   // Setup filter action buttons
   const resetBtn = document.getElementById('resetAllFiltersBtn');
-  
+
   if (resetBtn && typeof resetAllFilters === 'function') {
     resetBtn.addEventListener('click', () => {
       resetAllFilters();
     });
   }
-  
+
   // Setup CSV export functionality
   if (typeof window.LeaderboardCSVExport?.setupCSVExport === 'function') {
     window.LeaderboardCSVExport.setupCSVExport();
   }
-  
+
   // Setup citation export functionality
   if (typeof window.LeaderboardCitationExport?.setupCitationExport === 'function') {
     window.LeaderboardCitationExport.setupCitationExport();
   }
-  
+
   // Setup model search functionality
   if (typeof window.LeaderboardSearch?.setupSearchHandlers === 'function') {
     window.LeaderboardSearch.setupSearchHandlers();
   }
-  
+
   // Setup the reset benchmarks link
   setTimeout(() => {
     const resetLink = document.getElementById('resetBenchmarksLink');
     if (resetLink) {
       resetLink.addEventListener('click', (e) => {
         e.preventDefault();
-        
+
         // Check all checkboxes (include all benchmarks by default)
         const allCheckboxes = document.querySelectorAll('#benchmarkFilterPanel input[type="checkbox"]');
         allCheckboxes.forEach(cb => {
           cb.checked = true;  // Check everything including engineering
         });
-        
+
         // Rebuild the exclusion set
         window.filteredOutBenchmarks = new Set();
         allCheckboxes.forEach(cb => {
@@ -259,7 +296,7 @@ function setupEventHandlers() {
             window.filteredOutBenchmarks.add(cb.value);
           }
         });
-        
+
         // Trigger update
         if (typeof applyCombinedFilters === 'function') {
           applyCombinedFilters();
@@ -267,7 +304,7 @@ function setupEventHandlers() {
       });
     }
   }, 30);
-  
+
   setupLayoutToggleHandlers();
 }
 
@@ -276,10 +313,10 @@ function setupLayoutToggleHandlers() {
   const container = document.querySelector('.leaderboard-container');
   const advancedFilterBtn = document.getElementById('advancedFilterBtn');
   const layoutToggleBtn = document.getElementById('toggleLayoutBtn');
-  
+
   // Enhanced layout toggle functionality
   let isPanelVisible = false;
-  
+
   // Check for saved preference and set initial state
   const savedLayout = localStorage.getItem('leaderboardLayout');
   if (savedLayout === 'sidebar') {
@@ -295,11 +332,11 @@ function setupLayoutToggleHandlers() {
     isPanelVisible = false;
     updateToggleButton('horizontal');
   }
-  
+
   // Function to update toggle button text and icon
   function updateToggleButton(mode) {
     const toggleText = layoutToggleBtn?.querySelector('.toggle-text');
-    
+
     if (toggleText) {
       if (mode === 'sidebar') {
         toggleText.textContent = 'Full Width Mode';
@@ -308,7 +345,7 @@ function setupLayoutToggleHandlers() {
       }
     }
   }
-  
+
   // Function to position panel correctly
   function positionPanel(mode) {
     if (mode === 'horizontal') {
@@ -322,13 +359,13 @@ function setupLayoutToggleHandlers() {
       }
     }
   }
-  
+
   // Set initial position
   positionPanel(savedLayout === 'sidebar' ? 'sidebar' : 'horizontal');
-  
+
   layoutToggleBtn?.addEventListener('click', () => {
     const isSidebar = container.classList.toggle('sidebar-mode');
-    
+
     if (isSidebar) {
       positionPanel('sidebar');
       panel.classList.remove('hidden');
@@ -347,16 +384,16 @@ function setupLayoutToggleHandlers() {
       container.classList.remove('filters-hidden');
     }
   });
-  
+
   // Advanced filter button
   if (advancedFilterBtn) {
     const newAdvancedFilterBtn = advancedFilterBtn.cloneNode(true);
     advancedFilterBtn.parentNode.replaceChild(newAdvancedFilterBtn, advancedFilterBtn);
-    
+
     newAdvancedFilterBtn.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
-      
+
       if (!container.classList.contains('sidebar-mode')) {
         isPanelVisible = !isPanelVisible;
         if (isPanelVisible) {
@@ -386,7 +423,7 @@ function setupLayoutToggleHandlers() {
       }
     });
   }
-  
+
   // Final URL parsing with delay to avoid conflicts
   setTimeout(() => {
     if (typeof parseURLFilters === 'function') {

--- a/static/benchmarks/js/leaderboard/filters/filter-coordinator.js
+++ b/static/benchmarks/js/leaderboard/filters/filter-coordinator.js
@@ -3,7 +3,7 @@
 // Main function that applies all filters
 function applyCombinedFilters(skipColumnToggle = false, skipAutoSort = false) {
   if (!window.globalGridApi || !window.originalRowData) return;
-  
+
 
   if (typeof window.LeaderboardBenchmarkFilters?.updateBenchmarkFilters === 'function') {
     window.LeaderboardBenchmarkFilters.updateBenchmarkFilters();
@@ -113,13 +113,26 @@ function applyCombinedFilters(skipColumnToggle = false, skipAutoSort = false) {
     return true;
   });
 
-  // Update filtered scores on the filtered data BEFORE setting it on the grid
-  let finalData = filteredData;
+  // Apply wayback timestamp filtering first
+  let timestampFilteredData = filteredData;
+  if (typeof applyWaybackTimestampFilter === 'function') {
+    timestampFilteredData = applyWaybackTimestampFilter(filteredData);
+  }
+
+  // Initialize finalData
+  let finalData = timestampFilteredData;
+
+  // Update filtered scores
   if (typeof updateFilteredScores === 'function') {
-    const updatedData = updateFilteredScores(filteredData);
+    const updatedData = updateFilteredScores(timestampFilteredData);
     if (updatedData) {
       finalData = updatedData;
     }
+  }
+
+  // Additional pass: Remove models where global score is 'X'
+  if (typeof applyGlobalScoreModelRemoval === 'function') {
+    finalData = applyGlobalScoreModelRemoval(finalData);
   }
 
   // Update grid with filtered data - preserving original data structure
@@ -130,7 +143,7 @@ function applyCombinedFilters(skipColumnToggle = false, skipAutoSort = false) {
   if (!skipColumnToggle && typeof toggleFilteredScoreColumn === 'function') {
     toggleFilteredScoreColumn(window.globalGridApi);
   }
-  
+
   // Only update column visibility if we're not in the initial setup phase
   // During initial setup, setInitialColumnState() handles the column visibility
   if (typeof window.LeaderboardHeaderComponents?.updateColumnVisibility === 'function') {
@@ -152,6 +165,162 @@ function applyCombinedFilters(skipColumnToggle = false, skipAutoSort = false) {
   }
 }
 
+function isColumnHiddenByWaybackFiltering(benchmarkId) {
+  // Only check for wayback filtering if it's active
+  const minTimestamp = window.activeFilters?.min_wayback_timestamp;
+  const maxTimestamp = window.activeFilters?.max_wayback_timestamp;
+  const ranges = window.filterOptions?.datetime_range;
+  const fullRangeMin = ranges?.min_unix;
+  const fullRangeMax = ranges?.max_unix;
+  const isWaybackActive = minTimestamp && maxTimestamp && !(minTimestamp <= fullRangeMin && maxTimestamp >= fullRangeMax);
+
+  if (!isWaybackActive) {
+    return false; // No wayback filtering, column not hidden
+  }
+
+  // Get current row data from the grid
+  const rowData = [];
+  if (window.globalGridApi) {
+    window.globalGridApi.forEachNode(node => {
+      if (node.data) {
+        rowData.push(node.data);
+      }
+    });
+  }
+
+  if (rowData.length === 0) {
+    return false;
+  }
+
+  // Check if all values in this column are 'X'
+  const values = rowData.map(row => {
+    const cellData = row[benchmarkId];
+    return cellData && typeof cellData === 'object' ? cellData.value : cellData;
+  }).filter(val => val !== null && val !== undefined && val !== '');
+
+  if (values.length === 0) {
+    return false; // Don't hide if no values
+  }
+
+  const allXs = values.every(val => val === 'X');
+  return allXs;
+}
+
+function applyWaybackTimestampFilter(rowData) {
+  // Check if wayback timestamp filters are set and not at full range
+  const minTimestamp = window.activeFilters?.min_wayback_timestamp;
+  const maxTimestamp = window.activeFilters?.max_wayback_timestamp;
+
+  // Get the actual range limits from filter options
+  const ranges = window.filterOptions?.datetime_range;
+  const fullRangeMin = ranges?.min_unix;
+  const fullRangeMax = ranges?.max_unix;
+
+  const isAtFullRange = (minTimestamp <= fullRangeMin && maxTimestamp >= fullRangeMax);
+
+  if (!minTimestamp || !maxTimestamp || isAtFullRange) {
+    return rowData; // No timestamp filtering active
+  }
+
+  console.log('Applying wayback timestamp filter:', {
+    minTimestamp,
+    maxTimestamp,
+    minDate: new Date(minTimestamp * 1000).toISOString(),
+    maxDate: new Date(maxTimestamp * 1000).toISOString()
+  });
+
+  // Stats counters
+  let totalScoresProcessed = 0;
+  let scoresWithTimestamps = 0;
+  let scoresWithoutTimestamps = 0;
+  let scoresFilteredOut = 0;
+
+  const filteredWithValidModels = rowData.map(row => {
+    const newRow = { ...row };
+
+    Object.keys(row).forEach(key => {
+      if (row[key] && typeof row[key] === "object" && row[key].value !== undefined) {
+        totalScoresProcessed++;
+
+
+        const ts = row[key].timestamp;
+
+
+        if (!ts) {
+          scoresWithoutTimestamps++;
+          newRow[key] = { ...row[key], value: "X", color: "#E0E1E2" };
+        } else {
+          try {
+            const scoreTime = new Date(ts).getTime() / 1000; // Convert ISO string to Unix timestamp
+            if (scoreTime < minTimestamp || scoreTime > maxTimestamp) {
+              scoresFilteredOut++;
+              newRow[key] = { ...row[key], value: "X", color: "#E0E1E2" };
+            } else {
+              scoresWithTimestamps++;
+            }
+          } catch (error) {
+            scoresWithoutTimestamps++;
+            newRow[key] = { ...row[key], value: "X", color: "#E0E1E2" };
+          }
+        }
+      }
+    });
+
+    return newRow;
+  });
+
+  console.log("Wayback timestamp filtering results:", {
+    originalRows: rowData.length,
+    filteredRows: filteredWithValidModels.length,
+    totalScoresProcessed,
+    scoresWithTimestamps,
+    scoresWithoutTimestamps,
+    scoresFilteredOut,
+    percentageScoresWithTimestamps:
+      ((scoresWithTimestamps / Math.max(1, totalScoresProcessed)) * 100).toFixed(1) + "%",
+    percentageScoresFilteredOut:
+      ((scoresFilteredOut / Math.max(1, totalScoresProcessed)) * 100).toFixed(1) + "%"
+  });
+
+  return filteredWithValidModels;
+}
+
+function applyGlobalScoreModelRemoval(rowData) {
+  // Only apply this additional filtering if wayback timestamp filtering is active
+  const minTimestamp = window.activeFilters?.min_wayback_timestamp;
+  const maxTimestamp = window.activeFilters?.max_wayback_timestamp;
+
+  // Get the actual range limits from filter options
+  const ranges = window.filterOptions?.datetime_range;
+  const fullRangeMin = ranges?.min_unix;
+  const fullRangeMax = ranges?.max_unix;
+
+  const isAtFullRange = (minTimestamp <= fullRangeMin && maxTimestamp >= fullRangeMax);
+
+  if (!minTimestamp || !maxTimestamp || isAtFullRange) {
+    return rowData; // No wayback filtering active, don't remove any models
+  }
+
+  const originalCount = rowData.length;
+
+  // Filter out models where average_vision_v0 is 'X'
+  const filteredData = rowData.filter(row => {
+    const globalScore = row.average_vision_v0?.value;
+    return globalScore !== 'X';
+  });
+
+  const removedCount = originalCount - filteredData.length;
+
+  console.log('Global score model removal:', {
+    originalModels: originalCount,
+    modelsWithXGlobalScore: removedCount,
+    remainingModels: filteredData.length,
+    removedModels: removedCount > 0 ? rowData.filter(row => row.average_vision_v0?.value === 'X').slice(0, 3).map(row => row.model?.name || 'Unknown') : []
+  });
+
+  return filteredData;
+}
+
 // Reset all filters to default state
 function resetAllFilters() {
   window.activeFilters = {
@@ -169,7 +338,9 @@ function resetAllFilters() {
     benchmark_regions: [],
     benchmark_species: [],
     benchmark_tasks: [],
-    public_data_only: false
+    public_data_only: false,
+    min_wayback_timestamp: null,
+    max_wayback_timestamp: null
   };
 
   // Reset UI elements
@@ -285,7 +456,7 @@ function resetAllFilters() {
 
   // Apply filters but skip auto-sort during reset (allow column visibility updates)
   applyCombinedFilters(false, true);
-  
+
   // Reset sorting to original average_vision_v0 column when filters are reset
   if (window.globalGridApi) {
     setTimeout(() => {
@@ -297,7 +468,7 @@ function resetAllFilters() {
       });
     }, 100);
   }
-  
+
   if (typeof window.LeaderboardURLState?.updateURLFromFilters === 'function') {
     window.LeaderboardURLState.updateURLFromFilters();
   }
@@ -306,48 +477,48 @@ function resetAllFilters() {
 // Update filtered scores based on current filters
 function updateFilteredScores(rowData) {
   if (!window.originalRowData || !window.benchmarkTree) return;
-  
+
+  console.log('updateFilteredScores called - checking for wayback timestamp changes...');
+
   const excludedBenchmarks = new Set(window.filteredOutBenchmarks || []);
   const hierarchyMap = window.buildHierarchyFromTree(window.benchmarkTree);
-  
-  const workingRowData = rowData.map(row => ({ ...row }));
-  
-  // First restore original data for all columns
-  workingRowData.forEach((row) => {
-    const originalRow = window.originalRowData.find(origRow => origRow.id === row.id);
-    if (!originalRow) return;
-    
-    Object.keys(originalRow).forEach(key => {
-      if (key !== 'model' && key !== 'rank' && originalRow[key] && typeof originalRow[key] === 'object') {
-        row[key] = { ...originalRow[key] };
+
+  // Deep copy the rowData to preserve wayback timestamp filtering changes
+  const workingRowData = rowData.map(row => {
+    const newRow = { ...row };
+    // Deep copy all score objects to preserve wayback filtering changes
+    Object.keys(row).forEach(key => {
+      if (key !== 'model' && key !== 'rank' && key !== 'metadata' && row[key] && typeof row[key] === 'object') {
+        newRow[key] = { ...row[key] };
       }
     });
+    return newRow;
   });
-  
+
   // Then process each row for filtering
   workingRowData.forEach((row) => {
     const originalRow = window.originalRowData.find(origRow => origRow.id === row.id);
     if (!originalRow) return;
-    
+
     function getDepthLevel(benchmarkId, visited = new Set()) {
       if (visited.has(benchmarkId)) return 0;
       visited.add(benchmarkId);
-      
+
       const children = hierarchyMap.get(benchmarkId) || [];
       if (children.length === 0) return 0;
-      
+
       const maxChildDepth = Math.max(...children.map(child => getDepthLevel(child, new Set(visited))));
       return maxChildDepth + 1;
     }
-    
+
     const allBenchmarkIds = Array.from(hierarchyMap.keys());
     const benchmarksByDepth = allBenchmarkIds
       .map(id => ({ id, depth: getDepthLevel(id) }))
       .sort((a, b) => a.depth - b.depth);
-    
+
     benchmarksByDepth.forEach(({ id: benchmarkId }) => {
       const children = hierarchyMap.get(benchmarkId) || [];
-      
+
       if (children.length === 0) {
         if (excludedBenchmarks.has(benchmarkId)) {
           row[benchmarkId] = {
@@ -358,23 +529,23 @@ function updateFilteredScores(rowData) {
         }
       } else {
         const childScores = [];
-        
-        
+
+
         // First pass collect all children and determine if mixed valid/invalid scores
         const childInfo = [];
         children.forEach(childId => {
           if (!excludedBenchmarks.has(childId) && row[childId]) {
             const childScore = row[childId].value;
-            const hasValidScore = childScore !== null && childScore !== undefined && 
+            const hasValidScore = childScore !== null && childScore !== undefined &&
                                  childScore !== '' && childScore !== 'X' &&
                                  !isNaN(parseFloat(childScore));
             childInfo.push({ childId, childScore, hasValidScore });
           }
         });
-        
+
         // Check if any valid scores among the children
         const hasAnyValidScores = childInfo.some(info => info.hasValidScore);
-        
+
         // Second pass, build the scores array
         childInfo.forEach(({ childId, childScore, hasValidScore }) => {
           if (hasValidScore) {
@@ -387,11 +558,11 @@ function updateFilteredScores(rowData) {
           }
           // If no valid scores exist at all, skip everything (childScores will be empty)
         });
-        
-        
+
+
         // Check if we should drop out this parent column
         let shouldDropOut = false;
-        
+
         if (childScores.length === 0) {
           // No children available at all
           shouldDropOut = true;
@@ -399,7 +570,7 @@ function updateFilteredScores(rowData) {
           // Check if all non-excluded children are X or 0
           let validChildrenCount = 0;
           let nonZeroChildrenCount = 0;
-          
+
           children.forEach(childId => {
             if (!excludedBenchmarks.has(childId) && row[childId]) {
               validChildrenCount++;
@@ -412,11 +583,11 @@ function updateFilteredScores(rowData) {
               }
             }
           });
-          
+
           // Drop out if no valid children or all valid children are 0/X
           shouldDropOut = validChildrenCount === 0 || nonZeroChildrenCount === 0;
         }
-        
+
         if (shouldDropOut) {
           row[benchmarkId] = {
             ...row[benchmarkId],
@@ -432,14 +603,14 @@ function updateFilteredScores(rowData) {
         }
       }
     });
-    
+
     // Calculate global filtered score
     const visionCategories = ['neural_vision_v0', 'behavior_vision_v0'];
     const categoryScores = [];
-    
+
     visionCategories.forEach(category => {
       const isExcluded = excludedBenchmarks.has(category);
-      
+
       // Check if this column would be visible (not dropped out)
       let isColumnVisible = true;
       if (window.getFilteredLeafCount && typeof window.getFilteredLeafCount === 'function') {
@@ -448,7 +619,7 @@ function updateFilteredScores(rowData) {
           isColumnVisible = false; // Column is dropped out
         }
       }
-      
+
       // Only include in filtered score if column is visible and not excluded
       if (row[category] && !isExcluded && isColumnVisible) {
         const score = row[category].value;
@@ -468,8 +639,8 @@ function updateFilteredScores(rowData) {
         }
       }
     });
-    
-   
+
+
     if (categoryScores.length > 0) {
       const globalAverage = categoryScores.reduce((a, b) => a + b, 0) / categoryScores.length;
       row._tempFilteredScore = globalAverage;
@@ -481,15 +652,15 @@ function updateFilteredScores(rowData) {
   // Apply colors for recalculated benchmarks
   const allBenchmarkIds = Array.from(hierarchyMap.keys());
   const recalculatedBenchmarks = new Set();
-  
+
   allBenchmarkIds.forEach(benchmarkId => {
     const children = hierarchyMap.get(benchmarkId) || [];
-    
+
     if (children.length > 0) {
       const hasExcludedChildren = children.some(childId => excludedBenchmarks.has(childId));
       if (hasExcludedChildren) {
         recalculatedBenchmarks.add(benchmarkId);
-        
+
         function markAncestorsRecalculated(targetId) {
           allBenchmarkIds.forEach(parentId => {
             const parentChildren = hierarchyMap.get(parentId) || [];
@@ -503,7 +674,7 @@ function updateFilteredScores(rowData) {
       }
     }
   });
-  
+
   // Apply blue coloring for recalculated benchmarks
   allBenchmarkIds.forEach(benchmarkId => {
     if (recalculatedBenchmarks.has(benchmarkId)) {
@@ -517,12 +688,12 @@ function updateFilteredScores(rowData) {
           }
         }
       });
-      
+
       if (scores.length > 0) {
         const minScore = Math.min(...scores);
         const maxScore = Math.max(...scores);
         const scoreRange = maxScore - minScore;
-        
+
         workingRowData.forEach(row => {
           if (row[benchmarkId] && row[benchmarkId].value !== 'X') {
             const val = row[benchmarkId].value;
@@ -533,7 +704,7 @@ function updateFilteredScores(rowData) {
               const green = Math.round(173 + (105 * (1 - intensity)));
               const red = Math.round(216 * (1 - intensity));
               const color = `rgba(${red}, ${green}, ${baseBlue}, 0.6)`;
-              
+
               row[benchmarkId].color = color;
             }
           }
@@ -557,7 +728,7 @@ function updateFilteredScores(rowData) {
   const globalFilteredScores = workingRowData
     .map(row => row._tempFilteredScore)
     .filter(score => score !== null);
-    
+
   const globalMinScore = globalFilteredScores.length > 0 ? Math.min(...globalFilteredScores) : 0;
   const globalMaxScore = globalFilteredScores.length > 0 ? Math.max(...globalFilteredScores) : 1;
   const globalScoreRange = globalMaxScore - globalMinScore;
@@ -614,7 +785,7 @@ function toggleFilteredScoreColumn(gridApi) {
 
   const uncheckedCheckboxes = document.querySelectorAll('#benchmarkFilterPanel input[type="checkbox"]:not(:checked)');
   let hasNonEngineeringBenchmarkFilters = false;
-  
+
   // Only check for non-engineering benchmark filters if the benchmark panel is ready
   const benchmarkPanel = document.getElementById('benchmarkFilterPanel');
   if (benchmarkPanel && benchmarkPanel.children.length > 0) {
@@ -630,7 +801,7 @@ function toggleFilteredScoreColumn(gridApi) {
   }
 
   const shouldShowFilteredScore = hasNonEngineeringBenchmarkFilters || hasBenchmarkMetadataFilters;
-  
+
 
   if (shouldShowFilteredScore) {
     // First, make column visible
@@ -640,7 +811,7 @@ function toggleFilteredScoreColumn(gridApi) {
         { colId: 'average_vision_v0', hide: true }
       ]
     });
-    
+
     // Then apply sort with a small delay to ensure AG-Grid has processed the visibility change
     setTimeout(() => {
       // Try to simulate a manual click on the column header
@@ -652,7 +823,7 @@ function toggleFilteredScoreColumn(gridApi) {
             { colId: 'filtered_score', sort: 'desc' }
           ]
         });
-        
+
         // Verify it worked, and if not, try to trigger sort via the column API
         setTimeout(() => {
           const currentSort = filteredScoreColumn.getSort();
@@ -671,7 +842,7 @@ function toggleFilteredScoreColumn(gridApi) {
       ]
     });
   }
-  
+
   // Ensure column visibility is updated after changing filtered score visibility
   setTimeout(() => {
     if (typeof window.LeaderboardHeaderComponents?.updateColumnVisibility === 'function') {

--- a/static/benchmarks/js/leaderboard/filters/range-filters.js
+++ b/static/benchmarks/js/leaderboard/filters/range-filters.js
@@ -13,43 +13,60 @@ function initializeDualHandleSlider(container) {
   const minHandle = container.querySelector('.handle-min');
   const maxHandle = container.querySelector('.handle-max');
   const range = container.querySelector('.slider-range');
-  
+
   if (!minHandle || !maxHandle || !range) return;
-  
+
   const min = parseFloat(container.dataset.min) || 0;
   const max = parseFloat(container.dataset.max) || 100;
-  
+
   let minValue = parseFloat(minHandle.dataset.value) || min;
   let maxValue = parseFloat(maxHandle.dataset.value) || max;
-  
+
   // Find associated input fields
   const sliderGroup = container.closest('.filter-group');
-  const sliderType = sliderGroup?.querySelector('#paramCountMin') ? 'paramCount' : 
-                     sliderGroup?.querySelector('#modelSizeMin') ? 'modelSize' : 
-                     sliderGroup?.querySelector('#stimuliCountMin') ? 'stimuliCount' : 'unknown';
-  
+  const sliderType = sliderGroup?.querySelector('#paramCountMin') ? 'paramCount' :
+                     sliderGroup?.querySelector('#modelSizeMin') ? 'modelSize' :
+                     sliderGroup?.querySelector('#stimuliCountMin') ? 'stimuliCount' :
+                     sliderGroup?.querySelector('#waybackDateMin') ? 'waybackTimestamp' : 'unknown';
+
   const minInput = sliderGroup?.querySelector('.range-input-min');
   const maxInput = sliderGroup?.querySelector('.range-input-max');
-  
+
   function updateSliderPosition() {
     const minPercent = ((minValue - min) / (max - min)) * 100;
     const maxPercent = ((maxValue - min) / (max - min)) * 100;
-    
+
     minHandle.style.left = `${minPercent}%`;
     maxHandle.style.left = `${maxPercent}%`;
-    
+
     range.style.left = `${minPercent}%`;
     range.style.width = `${maxPercent - minPercent}%`;
-    
+
     // Update input fields
     if (minInput) minInput.value = Math.round(minValue);
     if (maxInput) maxInput.value = Math.round(maxValue);
+
+    if (sliderType === 'waybackTimestamp') {
+      // Convert Unix timestamps to date strings for date inputs
+      if (minInput) {
+        const minDate = new Date(minValue * 1000);
+        minInput.value = minDate.toISOString().split('T')[0];
+      }
+      if (maxInput) {
+        const maxDate = new Date(maxValue * 1000);
+        maxInput.value = maxDate.toISOString().split('T')[0];
+      }
+    } else {
+      // Standard numeric inputs
+      if (minInput) minInput.value = Math.round(minValue);
+      if (maxInput) maxInput.value = Math.round(maxValue);
+    }
   }
-  
+
   function updateActiveFilters(skipDebounce = false) {
     const filterId = container.closest('.filter-group').id;
-    
-    if (filterId === 'paramCountMin' || filterId === 'paramCountMax' || 
+
+    if (filterId === 'paramCountMin' || filterId === 'paramCountMax' ||
         sliderGroup?.querySelector('#paramCountMin') || sliderGroup?.querySelector('#paramCountMax')) {
       const oldValue = window.activeFilters.max_param_count;
       window.activeFilters.max_param_count = maxValue < max ? maxValue : null;
@@ -73,64 +90,75 @@ function initializeDualHandleSlider(container) {
         newFilterValue: window.activeFilters.max_model_size,
         skipDebounce
       });
+    } else if (filterId === 'waybackTimestampFilter' || sliderType === 'waybackTimestamp') {
+      window.activeFilters.min_wayback_timestamp = minValue;
+      window.activeFilters.max_wayback_timestamp = maxValue;
+      console.log(`🎚️ ${sliderType} filter update:`, {
+        minValue,
+        maxValue,
+        min: min,
+        max: max,
+        isAtFullRange: (minValue <= min && maxValue >= max),
+        skipDebounce
+      });
     }
-    
+
     // Apply filters with debouncing - but not during initial setup
     if (!skipDebounce) {
       console.log(`🎚️ ${sliderType} triggering debounceFilterUpdate`);
-      
+
       // If this is the stimuli count slider, also update benchmark filters
       if (sliderType === 'stimuliCount') {
         if (typeof window.LeaderboardBenchmarkFilters?.updateBenchmarkFilters === 'function') {
           window.LeaderboardBenchmarkFilters.updateBenchmarkFilters();
         }
       }
-      
+
       debounceFilterUpdate();
     }
   }
-  
+
   function handleMouseMove(e, handle, isMin) {
     const rect = container.getBoundingClientRect();
     const percent = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
     const value = min + percent * (max - min);
-    
+
     if (isMin) {
       minValue = Math.min(value, maxValue - 1);
     } else {
       maxValue = Math.max(value, minValue + 1);
     }
-    
+
     updateSliderPosition();
     updateActiveFilters();
   }
-  
+
   function addMouseListeners(handle, isMin) {
     let isDragging = false;
-    
+
     handle.addEventListener('mousedown', (e) => {
       isDragging = true;
       document.addEventListener('mousemove', mouseMoveHandler);
       document.addEventListener('mouseup', mouseUpHandler);
       e.preventDefault();
     });
-    
+
     function mouseMoveHandler(e) {
       if (isDragging) {
         handleMouseMove(e, handle, isMin);
       }
     }
-    
+
     function mouseUpHandler() {
       isDragging = false;
       document.removeEventListener('mousemove', mouseMoveHandler);
       document.removeEventListener('mouseup', mouseUpHandler);
     }
   }
-  
+
   addMouseListeners(minHandle, true);
   addMouseListeners(maxHandle, false);
-  
+
   // Input field synchronization
   if (minInput) {
     minInput.addEventListener('input', () => {
@@ -140,7 +168,7 @@ function initializeDualHandleSlider(container) {
       updateActiveFilters();
     });
   }
-  
+
   if (maxInput) {
     maxInput.addEventListener('input', () => {
       const value = parseFloat(maxInput.value) || max;
@@ -149,10 +177,28 @@ function initializeDualHandleSlider(container) {
       updateActiveFilters();
     });
   }
-  
+
+  // For minInput
+  if (sliderType === 'waybackTimestamp') {
+    // Convert date string to Unix timestamp
+    const dateValue = new Date(minInput.value);
+    value = isNaN(dateValue.getTime()) ? min : Math.floor(dateValue.getTime() / 1000);
+  } else {
+    value = parseFloat(minInput.value) || min;
+  }
+
+  // For maxInput
+  if (sliderType === 'waybackTimestamp') {
+    // Convert date string to Unix timestamp
+    const dateValue = new Date(maxInput.value);
+    value = isNaN(dateValue.getTime()) ? max : Math.floor(dateValue.getTime() / 1000);
+  } else {
+    value = parseFloat(maxInput.value) || max;
+  }
+
   // Initial position - don't trigger filters during setup
   updateSliderPosition();
-  
+
   // Update active filters without debouncing during initial setup
   updateActiveFilters(true);
 }
@@ -172,17 +218,17 @@ function debounceFilterUpdate() {
 function resetSliderUI() {
   const ranges = window.filterOptions || {};
   const sliderContainers = document.querySelectorAll('.slider-container');
-  
+
   sliderContainers.forEach(container => {
     const minHandle = container.querySelector('.handle-min');
     const maxHandle = container.querySelector('.handle-max');
     const range = container.querySelector('.slider-range');
-    
+
     if (!minHandle || !maxHandle || !range) return;
-    
+
     const min = parseFloat(container.dataset.min) || 0;
     let max = parseFloat(container.dataset.max) || 100;
-    
+
     // Use correct max values from filterOptions
     const sliderGroup = container.closest('.filter-group');
     if (sliderGroup?.querySelector('#paramCountMin') && ranges.parameter_ranges?.max) {
@@ -195,21 +241,21 @@ function resetSliderUI() {
       max = ranges.stimuli_ranges.max;
       container.dataset.max = max;
     }
-    
+
     // Reset to full range
     minHandle.style.left = '0%';
     maxHandle.style.left = '100%';
     range.style.left = '0%';
     range.style.width = '100%';
-    
+
     // Update data attributes
     minHandle.dataset.value = min;
     maxHandle.dataset.value = max;
-    
+
     // Update input fields
     const minInput = sliderGroup?.querySelector('.range-input-min');
     const maxInput = sliderGroup?.querySelector('.range-input-max');
-    
+
     if (minInput) minInput.value = min;
     if (maxInput) maxInput.value = max;
   });
@@ -219,12 +265,12 @@ function resetSliderUI() {
 function getRangeValues(filterId) {
   const container = document.querySelector(`#${filterId}`)?.closest('.filter-group')?.querySelector('.slider-container');
   if (!container) return null;
-  
+
   const minHandle = container.querySelector('.handle-min');
   const maxHandle = container.querySelector('.handle-max');
-  
+
   if (!minHandle || !maxHandle) return null;
-  
+
   return {
     min: parseFloat(minHandle.dataset.value) || 0,
     max: parseFloat(maxHandle.dataset.value) || 100
@@ -235,35 +281,35 @@ function getRangeValues(filterId) {
 function setRangeValues(filterId, minVal, maxVal) {
   const container = document.querySelector(`#${filterId}`)?.closest('.filter-group')?.querySelector('.slider-container');
   if (!container) return;
-  
+
   const minHandle = container.querySelector('.handle-min');
   const maxHandle = container.querySelector('.handle-max');
   const range = container.querySelector('.slider-range');
-  
+
   if (!minHandle || !maxHandle || !range) return;
-  
+
   const min = parseFloat(container.dataset.min) || 0;
   const max = parseFloat(container.dataset.max) || 100;
-  
+
   const minValue = Math.max(min, Math.min(minVal, max));
   const maxValue = Math.max(min, Math.min(maxVal, max));
-  
+
   minHandle.dataset.value = minValue;
   maxHandle.dataset.value = maxValue;
-  
+
   const minPercent = ((minValue - min) / (max - min)) * 100;
   const maxPercent = ((maxValue - min) / (max - min)) * 100;
-  
+
   minHandle.style.left = `${minPercent}%`;
   maxHandle.style.left = `${maxPercent}%`;
   range.style.left = `${minPercent}%`;
   range.style.width = `${maxPercent - minPercent}%`;
-  
+
   // Update input fields
   const sliderGroup = container.closest('.filter-group');
   const minInput = sliderGroup?.querySelector('.range-input-min');
   const maxInput = sliderGroup?.querySelector('.range-input-max');
-  
+
   if (minInput) minInput.value = Math.round(minValue);
   if (maxInput) maxInput.value = Math.round(maxValue);
 }

--- a/static/benchmarks/js/leaderboard/navigation/url-state.js
+++ b/static/benchmarks/js/leaderboard/navigation/url-state.js
@@ -3,13 +3,13 @@
 // Parse URL parameters and apply filters
 function parseURLFilters() {
   const urlParams = new URLSearchParams(window.location.search);
-  
+
   // Parse multi-select filters
   const parseList = (param) => {
     const value = urlParams.get(param);
     return value ? value.split(',').map(v => v.trim()) : [];
   };
-  
+
   window.activeFilters.architecture = parseList('architecture');
   window.activeFilters.model_family = parseList('model_family');
   window.activeFilters.training_dataset = parseList('training_dataset');
@@ -17,17 +17,17 @@ function parseURLFilters() {
   window.activeFilters.benchmark_regions = parseList('benchmark_regions');
   window.activeFilters.benchmark_species = parseList('benchmark_species');
   window.activeFilters.benchmark_tasks = parseList('benchmark_tasks');
-  
+
   // Parse boolean filters
   window.activeFilters.public_data_only = urlParams.get('public_data_only') === 'true';
   window.activeFilters.runnable_only = urlParams.get('runnable_only') === 'true';
-  
+
   // Parse range filters
   const parseFloatParam = (param) => {
     const value = urlParams.get(param);
     return value ? parseFloat(value) : null;
   };
-  
+
   window.activeFilters.min_param_count = parseFloatParam('min_param_count');
   window.activeFilters.max_param_count = parseFloatParam('max_param_count');
   window.activeFilters.min_model_size = parseFloatParam('min_model_size');
@@ -36,19 +36,21 @@ function parseURLFilters() {
   window.activeFilters.max_score = parseFloatParam('max_score');
   window.activeFilters.min_stimuli_count = parseFloatParam('min_stimuli_count');
   window.activeFilters.max_stimuli_count = parseFloatParam('max_stimuli_count');
-  
+  window.activeFilters.min_wayback_timestamp = parseFloatParam('min_wayback_timestamp');
+  window.activeFilters.max_wayback_timestamp = parseFloatParam('max_wayback_timestamp');
+
   // Apply filters to UI
   applyFiltersToUI();
-  
+
   // Parse benchmark exclusions
   const excludedBenchmarks = urlParams.get('excluded_benchmarks');
   if (excludedBenchmarks) {
     window.filteredOutBenchmarks = new Set(decodeBenchmarkFilters(excludedBenchmarks));
   }
-  
+
   // Update benchmark tree checkboxes
   updateBenchmarkTreeFromURL();
-  
+
   // Apply all filters
   if (typeof window.applyCombinedFilters === 'function') {
     window.applyCombinedFilters();
@@ -62,18 +64,18 @@ function applyFiltersToUI() {
   updateDropdownInput('modelFamilyFilter', window.activeFilters.model_family);
   updateDropdownInput('trainingDatasetFilter', window.activeFilters.training_dataset);
   updateDropdownInput('taskSpecFilter', window.activeFilters.task_specialization);
-  
+
   // Update checkboxes
   updateCheckboxes('.region-checkbox', window.activeFilters.benchmark_regions);
   updateCheckboxes('.species-checkbox', window.activeFilters.benchmark_species);
   updateCheckboxes('.task-checkbox', window.activeFilters.benchmark_tasks);
-  
+
   // Update boolean checkboxes
   const publicDataCheckbox = document.getElementById('publicDataFilter');
   if (publicDataCheckbox) {
     publicDataCheckbox.checked = window.activeFilters.public_data_only;
   }
-  
+
   // Update range inputs
   updateRangeInput('paramCountMin', window.activeFilters.min_param_count);
   updateRangeInput('paramCountMax', window.activeFilters.max_param_count);
@@ -81,7 +83,7 @@ function applyFiltersToUI() {
   updateRangeInput('modelSizeMax', window.activeFilters.max_model_size);
   updateRangeInput('stimuliCountMin', window.activeFilters.min_stimuli_count);
   updateRangeInput('stimuliCountMax', window.activeFilters.max_stimuli_count);
-  
+
   // Update range sliders
   if (typeof window.LeaderboardRangeFilters?.setRangeValues === 'function') {
     if (window.activeFilters.min_param_count !== null || window.activeFilters.max_param_count !== null) {
@@ -89,17 +91,33 @@ function applyFiltersToUI() {
       const max = window.activeFilters.max_param_count || 100;
       window.LeaderboardRangeFilters.setRangeValues('paramCountMin', min, max);
     }
-    
+
     if (window.activeFilters.min_model_size !== null || window.activeFilters.max_model_size !== null) {
       const min = window.activeFilters.min_model_size || 0;
       const max = window.activeFilters.max_model_size || 1000;
       window.LeaderboardRangeFilters.setRangeValues('modelSizeMin', min, max);
     }
-    
+
     if (window.activeFilters.min_stimuli_count !== null || window.activeFilters.max_stimuli_count !== null) {
       const min = window.activeFilters.min_stimuli_count || 0;
       const max = window.activeFilters.max_stimuli_count || 1000;
       window.LeaderboardRangeFilters.setRangeValues('stimuliCountMin', min, max);
+    }
+
+    if (window.activeFilters.min_wayback_timestamp !== null || window.activeFilters.max_wayback_timestamp !== null) {
+      // Update date inputs
+      const waybackDateMin = document.getElementById('waybackDateMin');
+      const waybackDateMax = document.getElementById('waybackDateMax');
+
+      if (waybackDateMin && window.activeFilters.min_wayback_timestamp) {
+        const minDate = new Date(window.activeFilters.min_wayback_timestamp * 1000);
+        waybackDateMin.value = minDate.toISOString().split('T')[0];
+      }
+
+      if (waybackDateMax && window.activeFilters.max_wayback_timestamp) {
+        const maxDate = new Date(window.activeFilters.max_wayback_timestamp * 1000);
+        waybackDateMax.value = maxDate.toISOString().split('T')[0];
+      }
     }
   }
 }
@@ -108,7 +126,7 @@ function applyFiltersToUI() {
 function updateDropdownInput(filterId, selectedValues) {
   const filter = document.getElementById(filterId);
   if (!filter || !selectedValues || selectedValues.length === 0) return;
-  
+
   const input = filter.querySelector('.filter-input');
   if (input) {
     input.value = selectedValues.join(', ');
@@ -134,7 +152,7 @@ function updateRangeInput(inputId, value) {
 // Update benchmark tree checkboxes based on URL exclusions
 function updateBenchmarkTreeFromURL() {
   const allCheckboxes = document.querySelectorAll('#benchmarkFilterPanel input[type="checkbox"]');
-  
+
   allCheckboxes.forEach(checkbox => {
     if (window.filteredOutBenchmarks && window.filteredOutBenchmarks.has(checkbox.value)) {
       checkbox.checked = false;
@@ -147,7 +165,7 @@ function updateBenchmarkTreeFromURL() {
 // Update URL with current filter state
 function updateURLFromFilters() {
   const params = new URLSearchParams();
-  
+
   // Add list parameters
   const addList = (key, urlParam) => {
     const param = urlParam || key;
@@ -155,7 +173,7 @@ function updateURLFromFilters() {
       params.set(param, window.activeFilters[key].join(','));
     }
   };
-  
+
   addList('architecture');
   addList('model_family');
   addList('training_dataset');
@@ -163,23 +181,23 @@ function updateURLFromFilters() {
   addList('benchmark_regions');
   addList('benchmark_species');
   addList('benchmark_tasks');
-  
+
   // Add boolean parameters
   if (window.activeFilters.public_data_only) {
     params.set('public_data_only', 'true');
   }
-  
+
   if (window.activeFilters.runnable_only) {
     params.set('runnable_only', 'true');
   }
-  
+
   // Add range parameters
   const addRange = (key) => {
     if (window.activeFilters[key] !== null && window.activeFilters[key] !== undefined) {
       params.set(key, window.activeFilters[key].toString());
     }
   };
-  
+
   addRange('min_param_count');
   addRange('max_param_count');
   addRange('min_model_size');
@@ -188,13 +206,15 @@ function updateURLFromFilters() {
   addRange('max_score');
   addRange('min_stimuli_count');
   addRange('max_stimuli_count');
-  
+  addRange('min_wayback_timestamp');
+  addRange('max_wayback_timestamp');
+
   // Add benchmark exclusions
   const excludedBenchmarks = encodeBenchmarkFilters();
   if (excludedBenchmarks) {
     params.set('excluded_benchmarks', excludedBenchmarks);
   }
-  
+
   // Update URL without page reload
   const newURL = `${window.location.pathname}?${params.toString()}`;
   window.history.replaceState({}, '', newURL);
@@ -205,14 +225,14 @@ function encodeBenchmarkFilters() {
   if (!window.filteredOutBenchmarks || window.filteredOutBenchmarks.size === 0) {
     return null;
   }
-  
+
   return Array.from(window.filteredOutBenchmarks).join(',');
 }
 
 // Decode benchmark filters from URL
 function decodeBenchmarkFilters(encodedFilters) {
   if (!encodedFilters) return [];
-  
+
   return encodedFilters.split(',').map(id => id.trim()).filter(id => id);
 }
 
@@ -226,11 +246,11 @@ function clearURLParameters() {
 function getCurrentURLParams() {
   const params = new URLSearchParams(window.location.search);
   const result = {};
-  
+
   for (const [key, value] of params.entries()) {
     result[key] = value;
   }
-  
+
   return result;
 }
 
@@ -244,7 +264,7 @@ function hasURLFilters() {
     'min_param_count', 'max_param_count', 'min_model_size', 'max_model_size',
     'min_score', 'max_score', 'min_stimuli_count', 'max_stimuli_count'
   ];
-  
+
   return filterParams.some(param => params.has(param));
 }
 

--- a/static/benchmarks/js/leaderboard/renderers/header-components.js
+++ b/static/benchmarks/js/leaderboard/renderers/header-components.js
@@ -4,8 +4,8 @@
 function buildHierarchyFromTree(tree, hierarchyMap = new Map()) {
   tree.forEach(node => {
     const nodeId = node.id || node.identifier || node.field || node.name;
-    const children = node.children ? 
-      node.children.map(child => child.id || child.identifier || child.field || child.name).filter(Boolean) : 
+    const children = node.children ?
+      node.children.map(child => child.id || child.identifier || child.field || child.name).filter(Boolean) :
       [];
     if (nodeId) {
       hierarchyMap.set(nodeId, children);
@@ -35,13 +35,13 @@ function createSortIndicator(params, element, fontSize = '12px') {
   indicator.style.marginLeft = '4px';
   indicator.style.fontSize = '16px';
   indicator.style.opacity = '0.87';
-  
+
   const updateSortIndicator = () => {
     const column = params.column;
     const currentSort = column.getSort();
-    
+
     indicator.classList.remove('ag-icon-asc', 'ag-icon-desc', 'ag-icon-none');
-    
+
     if (currentSort === 'asc') {
       indicator.classList.add('ag-icon-asc');
       indicator.style.opacity = '1';
@@ -56,7 +56,7 @@ function createSortIndicator(params, element, fontSize = '12px') {
 
   const handleSort = (event) => {
     event.stopPropagation();
-    
+
     const column = params.column;
     const colId = column.getColId();
     const currentSort = column.getSort();
@@ -68,7 +68,7 @@ function createSortIndicator(params, element, fontSize = '12px') {
         defaultState: { sort: null }
       });
     }
-    
+
     setTimeout(updateSortIndicator, 10);
   };
 
@@ -86,14 +86,14 @@ function createSortIndicator(params, element, fontSize = '12px') {
 // Update column visibility based on filtering state
 function updateColumnVisibility() {
   if (!window.globalGridApi || !window.benchmarkTree) return;
-  
+
   const hierarchyMap = buildHierarchyFromTree(window.benchmarkTree);
   const excludedBenchmarks = new Set(window.filteredOutBenchmarks || []);
-  
+
   // Get all columns
   const allColumns = window.globalGridApi.getAllGridColumns();
   const columnsToUpdate = [];
-  
+
   // Determine which columns should be visible based on:
   // 1. Current filter state (excluded benchmarks)
   // 2. Current expansion state (what the user has expanded)
@@ -102,7 +102,7 @@ function updateColumnVisibility() {
     if (excludedBenchmarks.has(benchmarkId)) {
       return false;
     }
-    
+
     // Check if this is the global score column and filtered score is active
     if (benchmarkId === 'average_vision_v0') {
       // Hide global score when filtered score is visible
@@ -112,7 +112,7 @@ function updateColumnVisibility() {
       }
       return true; // Show global score when filtered score is not active
     }
-    
+
     // Check if this is a top-level category
     const domain = (window.DJANGO_DATA && window.DJANGO_DATA.domain) || 'vision';
     const topLevelCategories = [`neural_${domain}_v0`, `behavior_${domain}_v0`, `engineering_${domain}_v0`];
@@ -126,7 +126,7 @@ function updateColumnVisibility() {
       }
       return true;
     }
-    
+
     // Determine if this is a leaf column or parent column (use cached hierarchy)
     if (!window.cachedHierarchyMap) {
       window.cachedHierarchyMap = buildHierarchyFromTree(window.benchmarkTree || []);
@@ -134,7 +134,7 @@ function updateColumnVisibility() {
     const hierarchyMap = window.cachedHierarchyMap;
     const children = hierarchyMap.get(benchmarkId) || [];
     const isLeafColumn = children.length === 0;
-    
+
     if (isLeafColumn) {
       // For leaf columns: hide if all values are X's or 0's
       if (shouldHideColumnWithAllXsOrZeros(benchmarkId)) {
@@ -148,8 +148,13 @@ function updateColumnVisibility() {
           return false;
         }
       }
+
+      // For wayback filtering, also hide parent columns if all their values are 'X'
+      if (shouldHideColumnWithAllXsOrZeros(benchmarkId)) {
+        return false;
+      }
     }
-    
+
     // For non-top-level benchmarks, check expansion state
     // Find the parent of this benchmark
     let parentId = null;
@@ -159,19 +164,19 @@ function updateColumnVisibility() {
         break;
       }
     }
-    
+
     if (!parentId) {
       // No parent found, treat as top-level
       return true;
     }
-    
+
     // Parent must be expanded and visible for this to be visible
     const isParentExpanded = window.columnExpansionState.get(parentId) === true;
     const isParentVisible = shouldColumnBeVisible(parentId);
-    
+
     return isParentExpanded && isParentVisible;
   }
-  
+
   function shouldHideColumnWithAllXsOrZeros(benchmarkId) {
     // Get current row data (filtered data)
     const rowData = [];
@@ -182,44 +187,72 @@ function updateColumnVisibility() {
         }
       });
     }
-    
+
     if (rowData.length === 0) {
       return false;
     }
-    
+
     // Check if all values in this column are X or 0
     const values = rowData.map(row => {
       const cellData = row[benchmarkId];
       return cellData && typeof cellData === 'object' ? cellData.value : cellData;
     }).filter(val => val !== null && val !== undefined && val !== '');
-    
+
     if (values.length === 0) {
       return false; // Don't hide if no values
     }
-    
+
+    // Check if wayback timestamp filtering is active
+    const minTimestamp = window.activeFilters?.min_wayback_timestamp;
+    const maxTimestamp = window.activeFilters?.max_wayback_timestamp;
+    const ranges = window.filterOptions?.datetime_range;
+    const fullRangeMin = ranges?.min_unix;
+    const fullRangeMax = ranges?.max_unix;
+    const isWaybackActive = minTimestamp && maxTimestamp && !(minTimestamp <= fullRangeMin && maxTimestamp >= fullRangeMax);
+
+    if (isWaybackActive) {
+      // For wayback filtering: hide only if ALL values are 'X' (not 0s, since 0s are legitimate scores)
+      const allXs = values.every(val => val === 'X');
+
+      // Determine if this is a parent or leaf column for better logging
+      const hierarchyMap = window.cachedHierarchyMap || new Map();
+      const children = hierarchyMap.get(benchmarkId) || [];
+      const columnType = children.length === 0 ? 'leaf' : 'parent';
+
+      // console.log(`Column visibility check for ${columnType} ${benchmarkId}:`, {
+      //   columnType,
+      //   totalValues: values.length,
+      //   allXs,
+      //   sampleValues: values.slice(0, 5),
+      //   isWaybackActive,
+      //   willHide: allXs
+      // });
+      return allXs;
+    }
+
     // Check if all values are 'X' or 0
     const allXsOrZeros = values.every(val => val === 'X' || val === 0);
-    
-    
+
+
     return allXsOrZeros;
   }
-  
+
   allColumns.forEach(column => {
     const colId = column.getColId();
-    
+
     // Skip non-benchmark columns (including runnable status)
     if (['model', 'rank', 'runnable_status', 'filtered_score'].includes(colId)) {
       return;
     }
-    
+
     const shouldShow = shouldColumnBeVisible(colId);
     const isCurrentlyVisible = column.isVisible();
-    
+
     if (shouldShow !== isCurrentlyVisible) {
       columnsToUpdate.push({ colId, hide: !shouldShow });
     }
   });
-  
+
   // Apply column visibility changes
   if (columnsToUpdate.length > 0) {
     window.globalGridApi.applyColumnState({
@@ -255,20 +288,20 @@ LeafHeaderComponent.prototype.init = function(params) {
   navigationArea.style.cursor = 'pointer';
   navigationArea.style.zIndex = '9';
   navigationArea.style.backgroundColor = 'transparent';
-  
+
   this.eGui.appendChild(navigationArea);
 
   navigationArea.addEventListener('click', (event) => {
     event.stopPropagation();
-    
+
     const colDef = params.column?.userProvidedColDef || params.column?.colDef || params.colDef || {};
     const benchmarkIdentifier = colDef.field || colDef.headerName || params.displayName;
-    
+
     if (!benchmarkIdentifier) {
       console.warn('Could not determine benchmark identifier from params:', params);
       return;
     }
-    
+
     const actualBenchmarkId = window.benchmarkIds && window.benchmarkIds[benchmarkIdentifier];
     if (actualBenchmarkId) {
       const domain = 'vision';
@@ -347,16 +380,16 @@ ExpandableHeaderComponent.prototype.init = function(params) {
     count.className = 'benchmark-count';
     count.style.cursor = 'pointer';
     count.dataset.parentField = colDef.field;
-    
+
     const icon = document.createElement('i');
     icon.className = 'fa-solid fa-up-right-and-down-left-from-center';
     icon.style.marginRight = '4px';
     icon.style.fontSize = '10px';
-    
+
     const countText = document.createElement('span');
     countText.className = 'count-value';
     countText.style.transition = 'all 0.2s ease';
-    
+
     // Calculate initial count
     let initialCount = 0;
     if (window.getFilteredLeafCount && typeof window.getFilteredLeafCount === 'function') {
@@ -374,9 +407,9 @@ ExpandableHeaderComponent.prototype.init = function(params) {
       // For other parent columns, use the number of direct children as fallback
       initialCount = directChildren.length;
     }
-    
+
     countText.textContent = initialCount;
-    
+
     count.appendChild(icon);
     count.appendChild(countText);
     this.eGui.appendChild(count);
@@ -391,24 +424,24 @@ ExpandableHeaderComponent.prototype.init = function(params) {
 
       if (shouldExpand) {
         const directChildIds = directChildren.map(c => c.getColId());
-        
+
         window.columnExpansionState.set(columnId, true);
         const showState = directChildIds.map(id => ({ colId: id, hide: false }));
         params.api.applyColumnState({ state: showState });
-        
+
         const allCols = params.api.getAllGridColumns();
         const parentIndex = allCols.findIndex(col => col.getColId() === columnId);
         if (parentIndex !== -1) {
           const insertIndex = parentIndex + 1;
           params.api.moveColumns(directChildIds, insertIndex);
         }
-        
+
         directChildIds.forEach(childId => {
           window.columnExpansionState.set(childId, false);
         });
-        
+
         icon.className = 'fa-solid fa-down-left-and-up-right-to-center';
-        
+
       } else {
         // Collapse: hide ALL descendants recursively
         const allCols = params.api.getAllGridColumns();
@@ -416,19 +449,19 @@ ExpandableHeaderComponent.prototype.init = function(params) {
           .map(id => allCols.find(col => col.getColId() === id))
           .filter(Boolean)
           .map(col => col.getColId());
-        
+
         // Use applyColumnState
         const hideState = allDescendantIds.map(id => ({ colId: id, hide: true }));
         params.api.applyColumnState({ state: hideState });
-        
+
         // Update expansion state
         window.columnExpansionState.set(columnId, false);
-        
+
         // Mark all descendants as collapsed
         allDescendantIds.forEach(descendantId => {
           window.columnExpansionState.set(descendantId, false);
         });
-        
+
         icon.className = 'fa-solid fa-up-right-and-down-left-from-center';
       }
 
@@ -436,7 +469,7 @@ ExpandableHeaderComponent.prototype.init = function(params) {
       if (toggle) {
         toggle.textContent = shouldExpand ? '▴' : '▾';
       }
-      
+
       // Debounced column visibility update after expand/collapse
       if (window.expandCollapseUpdateTimeout) {
         clearTimeout(window.expandCollapseUpdateTimeout);
@@ -465,9 +498,9 @@ ExpandableHeaderComponent.prototype.init = function(params) {
       if (event.target.closest('.expandable-header .benchmark-count') || event.target.closest('.sort-indicator')) {
         return;
       }
-      
+
       event.stopPropagation();
-      
+
       const column = params.column;
       const colId = column.getColId();
       const currentSort = column.getSort();

--- a/static/benchmarks/js/leaderboard/ui/ui-handlers.js
+++ b/static/benchmarks/js/leaderboard/ui/ui-handlers.js
@@ -2,7 +2,7 @@
 
 // Setup all UI handlers
 function setupUIHandlers(panel, container, advancedFilterBtn, layoutToggleBtn) {
-  
+
   // Advanced filters panel toggle
   if (advancedFilterBtn && panel) {
     advancedFilterBtn.addEventListener('click', function() {
@@ -26,7 +26,7 @@ function setupUIHandlers(panel, container, advancedFilterBtn, layoutToggleBtn) {
     });
   } else {
   }
-  
+
   // Layout toggle button
   if (layoutToggleBtn && panel && container) {
     layoutToggleBtn.addEventListener('click', function() {
@@ -40,7 +40,7 @@ function setupUIHandlers(panel, container, advancedFilterBtn, layoutToggleBtn) {
       }
     });
   }
-  
+
   // Reset all filters button
   const resetAllFiltersBtn = document.getElementById('resetAllFiltersBtn');
   if (resetAllFiltersBtn) {
@@ -50,36 +50,36 @@ function setupUIHandlers(panel, container, advancedFilterBtn, layoutToggleBtn) {
       }
     });
   }
-  
+
   // Reset benchmarks link
   const resetBenchmarksLink = document.getElementById('resetBenchmarksLink');
   if (resetBenchmarksLink) {
     resetBenchmarksLink.addEventListener('click', function(e) {
       e.preventDefault();
-      
+
       // Check all benchmark checkboxes
       const checkboxes = document.querySelectorAll('#benchmarkFilterPanel input[type="checkbox"]');
       checkboxes.forEach(cb => {
         cb.checked = true;
       });
-      
+
       // Clear filtered benchmarks
       if (window.filteredOutBenchmarks) {
         window.filteredOutBenchmarks.clear();
       }
-      
+
       // Apply filters (skip auto-sort since this is a reset operation, but allow column visibility updates)
       if (typeof window.applyCombinedFilters === 'function') {
         window.applyCombinedFilters(false, true);
       }
     });
   }
-  
+
 }
 
 // Initialize filters from URL parameters or set defaults
 function initializeFilters() {
-  
+
   // Try to parse URL filters first
   if (typeof window.LeaderboardURLState?.parseURLFilters === 'function') {
     try {
@@ -87,7 +87,7 @@ function initializeFilters() {
     } catch (e) {
     }
   }
-  
+
   // If no URL filters, ensure filters are in default state
   if (!window.activeFilters) {
     window.activeFilters = {
@@ -105,22 +105,24 @@ function initializeFilters() {
       benchmark_regions: [],
       benchmark_species: [],
       benchmark_tasks: [],
-      public_data_only: false
+      public_data_only: false,
+      min_wayback_timestamp: null,
+      max_wayback_timestamp: null
     };
   }
-  
+
   // Initialize filtered benchmarks set if not exists
   if (!window.filteredOutBenchmarks) {
     window.filteredOutBenchmarks = new Set();
   }
-  
+
   // Apply initial filters (skip column toggle during initialization)
   if (typeof window.applyCombinedFilters === 'function') {
     setTimeout(() => {
       window.applyCombinedFilters(true);
     }, 100);
   }
-  
+
 }
 
 // Export functions for use by other modules
@@ -132,4 +134,3 @@ window.LeaderboardUIHandlers = {
 // Make functions globally available for compatibility
 window.setupUIHandlers = setupUIHandlers;
 window.initializeFilters = initializeFilters;
-


### PR DESCRIPTION
_Author_: Nathan Teshome

_Summary_:
This pull request introduces the working version of the Brain-score Wayback Filter, developed as part of my UROP project.

The goal of this tool is to introduce a dual-date slider similar to the existing sliders in Benchmark Properties to synchronize date inputs that let users travel through the leaderboard to any historical window, so models and scores are shown as they existed then, not just today. The feature wires the UI to backend filtering on Score.end_timestamp, adds similar robust UX behaviors (keyboard & mouse), and ensures performant, debounced grid updates in AG Grid.

_Features Implemented_:

- Dual Date Slider (Wayback UI)
  - Interactive two-handle slider for start and end dates with live labels.
  - Calendar that supports date time filtering through date selection.
  - Direct text inputs mirror the slider; changes in either stay in sync.
  - Debounced updates to avoid excessive renders/network calls while dragging.
  
- Backend Time-Window Filtering
  - Leaderboard rows filter by Score.end_timestamp (leaf scores only), matching the Brain-Score data model.
  - Supports open-ended ranges (only start or only end provided).

- AG Grid Integration
  - Efficient row filtering without full data reloads; preserves column state, sort, and selection.
  - Visual highlight of filtered state; clear-filters control restores full view.

_FInal Visualization Demo:_


https://github.com/user-attachments/assets/0ad8aef9-8285-48d8-a91c-256e723537e2

 