### PR TITLE
Reject metadata.yaml in model submissions and submission page URL

### DIFF
--- a/benchmarks/templates/benchmarks/profile.html
+++ b/benchmarks/templates/benchmarks/profile.html
@@ -38,7 +38,7 @@
             </div>
             <br>
         <p class="benefits_info is-size-5-mobile">
-            Submit new {{ domain }} plugins <a href="{{ request.build_absolute_uri }}submit">here</a>.
+            Submit new {{ domain }} plugins <a href="/profile/{{ domain }}/submit/">here</a>.
         </p>
 
         </form>

--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -427,11 +427,11 @@ def validate_zip(file: InMemoryUploadedFile) -> Tuple[bool, str]:
         for item in namelist:
             if ' ' in item.filename:
                 return False, f"File '{item.filename}' contains spaces. Please remove spaces from all file names."
-                
+
             # Check for metadata files
             filename = item.filename.lower()
             if filename.endswith('metadata.yaml') or filename.endswith('metadata.yml'):
-                return False, f"We currently do not support metadata files in user submissions. Please remove metadata.yaml/metadata.yml files from your submission."
+                return False, f"We currently do not support user-contributed metadata files. Please remove the metadata.yaml/metadata.yml files from your submission."
 
         root = namelist[0]
         has_plugin, submitted_plugins = plugins_exist(namelist)

--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -427,6 +427,11 @@ def validate_zip(file: InMemoryUploadedFile) -> Tuple[bool, str]:
         for item in namelist:
             if ' ' in item.filename:
                 return False, f"File '{item.filename}' contains spaces. Please remove spaces from all file names."
+                
+            # Check for metadata files
+            filename = item.filename.lower()
+            if filename.endswith('metadata.yaml') or filename.endswith('metadata.yml'):
+                return False, f"We currently do not support metadata files in user submissions. Please remove metadata.yaml/metadata.yml files from your submission."
 
         root = namelist[0]
         has_plugin, submitted_plugins = plugins_exist(namelist)


### PR DESCRIPTION
Two fixes:
1. Reject metadata.yaml/yml files in model submissions.
2. Fix that way the `Submit new plugins here` link directs to submission portal. Previously was using absolute URL (which for the AG-Grid leaderboard now includes URL parameters). This was resulting in malformed URLs that look like: `http://localhost:8000/profile/vision/?min_param_count=0&max_param_count=100&min_model_size=0&max_model_size=1000&min_score=0&max_score=1&min_stimuli_count=0&max_stimuli_count=51000submitsubmitsubmitsubmitsubmit`


## Screenshot of metadata rejection
<img width="1392" height="1521" alt="image" src="https://github.com/user-attachments/assets/a14da16f-ad48-4d01-8e94-c9b20e39162b" />
