### PR TITLE
Show benchmark identifier in tooltip on hover over header

### DIFF
--- a/static/benchmarks/js/leaderboard/renderers/header-components.js
+++ b/static/benchmarks/js/leaderboard/renderers/header-components.js
@@ -239,10 +239,20 @@ LeafHeaderComponent.prototype.init = function(params) {
   const label = document.createElement('span');
   label.className = 'leaf-header-label';
   label.textContent = params.displayName || params.colDef.headerName;
-  label.title = label.textContent;
 
   this.eGui.appendChild(label);
   createSortIndicator(params, this.eGui);
+
+  // Add custom tooltip with instant display for child headers
+  if (typeof addHoverTooltip === 'function') {
+    addHoverTooltip(this.eGui, label.textContent, { 
+      type: 'info', 
+      position: 'top'
+    });
+  } else {
+    // Fallback to native title attribute
+    this.eGui.title = label.textContent;
+  }
 
   // Navigation functionality
   const navigationArea = document.createElement('div');
@@ -315,7 +325,17 @@ ExpandableHeaderComponent.prototype.init = function(params) {
   const title = document.createElement('span');
   title.className = 'expandable-header-label';
   title.textContent = displayName;
-  title.title = displayName;
+  
+  // Add custom tooltip with instant display for parent headers
+  if (typeof addHoverTooltip === 'function') {
+    addHoverTooltip(title, displayName, { 
+      type: 'info', 
+      position: 'top'
+    });
+  } else {
+    // Fallback to native title attribute
+    title.title = displayName;
+  }
 
   labelContainer.appendChild(title);
   this.eGui.appendChild(labelContainer);


### PR DESCRIPTION
Addresses #467. Column headers are a fixed width. Benchmark identifiers often are long and get cut off. Many benchmark identifiers in a family of benchmarks (e.g., Ferguson2024) start the same and then get cut off where the identifier becomes different. Now, on hover over header, the full identifier is displayed in a tooltip.

<img width="1550" height="1347" alt="image" src="https://github.com/user-attachments/assets/687bfff0-50f1-4690-81b6-03747bc4dce9" />
