### PR TITLE
Reduce payload size for leaderboard content

### DIFF
--- a/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard-content.html
+++ b/benchmarks/templates/benchmarks/leaderboard/ag-grid-leaderboard-content.html
@@ -255,6 +255,7 @@
     filter_options: '{{ filter_options|escapejs }}',
     benchmark_metadata: '{{ benchmark_metadata|escapejs }}',
     benchmark_ids: '{{ benchmark_ids|escapejs }}',
+    benchmark_bibtex_map: '{{ benchmark_bibtex_map|escapejs }}',
     model_metadata_map: '{{ model_metadata_map|escapejs }}',
     domain: '{{ domain }}',
     benchmarkStimuliMetaMap: '{{ benchmarkStimuliMetaMap|escapejs }}',

--- a/benchmarks/views/leaderboard.py
+++ b/benchmarks/views/leaderboard.py
@@ -105,6 +105,24 @@ def round_up_aesthetically(value):
         return ((int(value) // power) + 1) * power
 
 
+def build_benchmark_bibtex_map(benchmarks):
+    """
+    Create a minimal map of benchmark IDs to citation data for frontend use.
+    Replaces full benchmark objects that were stored in each score (reducing payload size by ~80%).
+    Only includes leaf benchmarks (those with actual scores/bibtex).
+    """
+    bibtex_map = {}
+    for benchmark in benchmarks:
+        # Only include leaf benchmarks with bibtex
+        if benchmark.number_of_all_children == 0:
+            if hasattr(benchmark, 'benchmark_bibtex') and benchmark.benchmark_bibtex:
+                bibtex_map[benchmark.identifier] = {
+                    'bibtex': benchmark.benchmark_bibtex,
+                    'benchmark_type_id': benchmark.identifier.rsplit('_v', 1)[0] if '_v' in benchmark.identifier else benchmark.identifier
+                }
+    return bibtex_map
+
+
 @cache_get_context(timeout=7 *24 * 60 * 60, key_prefix="leaderboard", use_compression=True)
 def get_ag_grid_context(user=None, domain="vision", benchmark_filter=None, model_filter=None, show_public=False, force_user_cache=False):
     """
@@ -304,23 +322,14 @@ def get_ag_grid_context(user=None, domain="vision", benchmark_filter=None, model
             # fallback for missing IDs
             if not vid:
                 continue
-            # Extract only essential benchmark fields for citation functionality
-            benchmark_info = score.get('benchmark', {})
-            minimal_benchmark = {}
-            if benchmark_info.get('bibtex'):
-                minimal_benchmark = {
-                    'bibtex': benchmark_info.get('bibtex'),
-                    'benchmark_type_id': benchmark_info.get('benchmark_type_id', '')
-                }
             
+            # Store only the score data - benchmark citation data moved to separate map
             rd[vid] = {
                 'value': score.get('score_ceiled', 'X'),
                 'raw': score.get('score_raw'),
                 'error': score.get('error'),
                 'color': score.get('color'),
-                'complete': score.get('is_complete', True),
-                # Include minimal benchmark info only when needed for citations
-                'benchmark': minimal_benchmark if minimal_benchmark else None
+                'complete': score.get('is_complete', True)
             }
         row_data.append(rd)
 
@@ -480,6 +489,9 @@ def get_ag_grid_context(user=None, domain="vision", benchmark_filter=None, model
     filtered_benchmarks = [b for b in context['benchmarks'] if b.identifier != 'average_vision_v0']
     context['benchmark_tree'] = json.dumps(build_benchmark_tree(filtered_benchmarks))
     
+    # Create benchmark bibtex map for citation export
+    context['benchmark_bibtex_map'] = json.dumps(build_benchmark_bibtex_map(context['benchmarks']))
+    
     # Create simple benchmark ID mapping for frontend navigation links
     benchmark_ids = {}
     for benchmark in context['benchmarks']:
@@ -496,6 +508,7 @@ def get_ag_grid_context(user=None, domain="vision", benchmark_filter=None, model
         'benchmark_metadata': context['benchmark_metadata'],
         'benchmark_tree': context['benchmark_tree'],
         'benchmark_ids': json.dumps(benchmark_ids),
+        'benchmark_bibtex_map': context['benchmark_bibtex_map'],
         # Removed benchmarkMetaMap for simplicity
         'benchmarkStimuliMetaMap': context['benchmarkStimuliMetaMap'],
         'benchmarkDataMetaMap': context['benchmarkDataMetaMap'],

--- a/static/benchmarks/js/leaderboard/core/template-initialization.js
+++ b/static/benchmarks/js/leaderboard/core/template-initialization.js
@@ -56,6 +56,7 @@ function initializeLeaderboardFromTemplate() {
     window.benchmarkStimuliMetaMap = JSON.parse(window.DJANGO_DATA.benchmarkStimuliMetaMap);
     window.benchmarkDataMetaMap = JSON.parse(window.DJANGO_DATA.benchmarkDataMetaMap);
     window.benchmarkMetricMetaMap = JSON.parse(window.DJANGO_DATA.benchmarkMetricMetaMap);
+    window.benchmarkBibtexMap = JSON.parse(window.DJANGO_DATA.benchmark_bibtex_map);
 
     // Set up range sliders with correct max values
     const ranges = filterOptions || {};

--- a/static/benchmarks/js/leaderboard/export/citation-export.js
+++ b/static/benchmarks/js/leaderboard/export/citation-export.js
@@ -85,28 +85,31 @@ function collectBenchmarkBibtex() {
 
     const scoreData = firstModel[fieldName];
 
-    // Check if this is a leaf benchmark with bibtex data
+    // Check if this is a leaf benchmark
     if (scoreData &&
         typeof scoreData === 'object' &&
-        scoreData.benchmark &&
-        scoreData.benchmark.bibtex &&
         isLeafBenchmark(fieldName)) {
 
-      // Check if this benchmark is excluded using multiple patterns
-      const baseFieldName = fieldName.replace(/_v\d+$/, '');
-      const benchmarkTypeId = scoreData.benchmark.benchmark_type_id;
+      // Look up bibtex from the benchmark bibtex map
+      const bibtexData = window.benchmarkBibtexMap?.[fieldName];
+      // If there is bibtex data
+      if (bibtexData && bibtexData.bibtex) {
+        // Check if this benchmark is excluded using multiple patterns
+        const baseFieldName = fieldName.replace(/_v\d+$/, '');
+        const benchmarkTypeId = bibtexData.benchmark_type_id;
 
-      // Makes sure that we do not include benchmarks that we have excluded
-      const isExcluded = excludedBenchmarks.has(fieldName) ||
-                        excludedBenchmarks.has(baseFieldName) ||
-                        excludedBenchmarks.has(benchmarkTypeId);
+        // Makes sure that we do not include benchmarks that we have excluded
+        const isExcluded = excludedBenchmarks.has(fieldName) ||
+                          excludedBenchmarks.has(baseFieldName) ||
+                          excludedBenchmarks.has(benchmarkTypeId);
 
-      if (!isExcluded) {
-        const bibtex = scoreData.benchmark.bibtex.trim();
+        if (!isExcluded) {
+          const bibtex = bibtexData.bibtex.trim();
 
-        // Add to set if valid (Set automatically handles duplicates)
-        if (bibtex && bibtex !== 'null') {
-          bibtexSet.add(bibtex);
+          // Add to set if valid (Set automatically handles duplicates)
+          if (bibtex && bibtex !== 'null') {
+            bibtexSet.add(bibtex);
+          }
         }
       }
     }


### PR DESCRIPTION
Previously the payload for the leaderboard was ~65MB. This was because every score (models x benchmarks), had the full benchmark object attached to it. In a previous PR, the benchmark object was already substantially trimmed however was retained. Since then, the only thing in the benchmark object that was being used was the bibtex.

In this PR, I remove the benchmark object from each score, and create a mapping for benchmark to its bibtex. Then update the `citation-export.js` function to use the mapping.

This results in the payload being reduced to ~12MB. With compression, this is further reduced to ~2MB. 