### PR TITLE
Fix copy to clipboard code

### DIFF
--- a/benchmarks/templates/benchmarks/central_profile.html
+++ b/benchmarks/templates/benchmarks/central_profile.html
@@ -96,7 +96,7 @@ file_path = load_file(bucket="brainscore-storage", folder_name="brainscore-{{ f.
                               </button>
                               <div class="python-tooltip">
                                 <p>To use this file, copy and paste the code below into your Brain-Score plugin file:</p>
-<pre><code>from brainscore_core.supported_data_standards.brainio.s3 import  import load_file
+<pre><code>from brainscore_core.supported_data_standards.brainio.s3 import load_file
 file_path = load_file(bucket="brainscore-storage", folder_name="brainscore-{{ f.domain }}/{{ f.plugin_type }}/user_{{ request.user.id }}/",
                       relative_path="{{f.filename}}",
                       version_id="{{f.version_id}}",


### PR DESCRIPTION
The tooltip should mostly correct code but the copied text was the original deprecated function from model_helpers.s3.