### PR TITLE
add lang size support

### DIFF
--- a/benchmarks/forms.py
+++ b/benchmarks/forms.py
@@ -67,6 +67,15 @@ class UploadPlaceHolder(forms.Form):
     config_file = forms.FileField(help_text='Required')
 
 
+MODEL_SIZE_CHOICES = [
+    ('', 'Select model size...'),
+    ('small', 'Small (< 3B params)'),
+    ('medium', 'Medium (3–13B params)'),
+    ('large', 'Large (13–50B params)'),
+    ('xlarge', 'XLarge (50–120B params)'),
+]
+
+
 class UploadFileForm(forms.Form):
     zip_file = forms.FileField(label="", help_text='Required')
     public = forms.BooleanField(
@@ -76,6 +85,13 @@ class UploadFileForm(forms.Form):
         widget=ToggleSwitchWidget(),
         help_text='Toggle if you want the results of your submitted models included in the '
                   'public ranking.',
+    )
+    model_size = forms.ChoiceField(
+        label='Model Size:',
+        choices=MODEL_SIZE_CHOICES,
+        required=False,
+        widget=forms.Select(attrs={'style': 'width: 100%; padding: 8px; border-radius: 4px; border: 1px solid #ccc;'}),
+        help_text='Approximate parameter count of your model.',
     )
 
     class Meta:

--- a/benchmarks/templates/benchmarks/upload.html
+++ b/benchmarks/templates/benchmarks/upload.html
@@ -25,7 +25,24 @@
                 {% csrf_token %}
 
                 {% for field in form %}
-                    {% if field.name == 'public' %}
+                    {% if field.name == 'model_size' %}
+                        {% if domain == 'language' %}
+                        <div class="special" style="margin-top: 20px;">
+                            {{ field.label_tag }} <span style="color: #e74c3c; font-weight: bold;">*</span>
+                            {{ field }}
+                            <small style="color: #6b7280; font-size: 11px; margin-top: 4px; display: block;">
+                                Required — select the approximate parameter count of your model.
+                                <span id="model-size-info-icon" style="position: relative; cursor: help; border-bottom: 1px dotted #6b7280;" title="16-bit or lower quantization is required for models with more than 50B parameters. Brain-Score is currently limited to models under 130B parameters. If you have a larger model you would like scored, please contact the team." onclick="var tip=document.getElementById('model-size-tooltip'); tip.style.display = tip.style.display === 'block' ? 'none' : 'block';">ⓘ</span>
+                                <span id="model-size-tooltip" style="display: none; margin-top: 6px; padding: 8px 10px; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px; font-size: 11px; color: #333; line-height: 1.4;">
+                                    16-bit or lower quantization is required for models with more than 50B parameters. Brain-Score is currently limited to models under 130B parameters. If you have a larger model you would like scored, please contact the team.
+                                </span>
+                            </small>
+                            {% for error in field.errors %}
+                                <p style="color: red">{{ error }}</p>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                    {% elif field.name == 'public' %}
                     <div class="special" style="margin-top: 20px; display: flex; align-items: center; gap: 8px; font-size: 13px;">
                         {{ field.label_tag }}{{ field }}
                     </div>

--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -4,7 +4,7 @@ import zipfile
 import re
 import uuid
 from typing import Tuple, Union, List
-from io import TextIOWrapper
+from io import BytesIO, TextIOWrapper
 import boto3
 import requests
 from botocore.exceptions import ClientError
@@ -290,14 +290,19 @@ class Upload(View):
         if request.user.is_anonymous:
             return HttpResponseRedirect(f'../profile/{self.domain}')
         form = UploadFileForm()
+        if self.domain == 'language':
+            form.fields['model_size'].required = True
         return render(request, 'benchmarks/upload.html',
                       {'form': form, 'domain': self.domain, 'formatted': self.domain.capitalize()})
 
     def post(self, request):
         assert self.domain is not None
         form = UploadFileForm(request.POST, request.FILES)
+        if self.domain == 'language':
+            form.fields['model_size'].required = True
         if not form.is_valid():
-            return HttpResponse("Form is invalid", status=400)
+            return render(request, 'benchmarks/upload.html',
+                          {'form': form, 'domain': self.domain, 'formatted': self.domain.capitalize()})
 
         user_instance = User.objects.get_by_natural_key(request.user.email)
 
@@ -323,16 +328,18 @@ class Upload(View):
             return render(request, f'benchmarks/{page}_submitted.html',
                           {'plugin': plugin, 'identifier': identifier, "domain": self.domain})
 
+        model_size = request.POST.get('model_size', '') if self.domain == 'language' else ''
+
         json_info = {
             "model_type": request.POST['model_type'] if "model_type" in form.base_fields else "BrainModel",
             "user_id": user_instance.id,
             "public": str('public' in request.POST),
             "competition": 'cosyne2022' if 'competition' in request.POST and request.POST['competition'] else None,
-            "domain": self.domain
+            "domain": self.domain,
+            "model_size": model_size,
         }
 
-        with open('result.json', 'w') as fp:
-            json.dump(json_info, fp)
+        config_bytes = json.dumps(json_info).encode('utf-8')
 
         _logger.debug(request.user.get_full_name())
         _logger.debug(f"request user: {request.user.get_full_name()}")
@@ -345,7 +352,10 @@ class Upload(View):
                       f"?TOKEN=trigger2scoreAmodel" \
                       f"&email={request.user.email}"
         _logger.debug(f"request_url: {request_url}")
-        params = {"submission.zip": request.FILES['zip_file'], 'submission.config': open('result.json', 'rb')}
+        params = {
+            "submission.zip": request.FILES['zip_file'],
+            'submission.config': ('submission.config', BytesIO(config_bytes)),
+        }
         response = requests.post(request_url, files=params, auth=auth)
         _logger.debug(f"response: {response}")
 

--- a/static/benchmarks/css/login.sass
+++ b/static/benchmarks/css/login.sass
@@ -9,6 +9,7 @@ $brainscore_blue: #47B7DE
   border-radius: 40px
   background-size: cover
   background-repeat: no-repeat
+  background-position: center
 
 .container.login::before
   content: ""
@@ -83,10 +84,10 @@ p.create-account, p.create-account a
     margin-left: 20px
 
 
-// FHD
+// FHD - keep brain background centered at all viewport sizes
 @media (max-width: 1407px)
    .container.login
-    background-position-x: -150px
+    background-position: center
 
 //wrong password error message effect:
 @keyframes fadeOut


### PR DESCRIPTION
## Language submission: model size, UI tweak

### Model size dropdown (language only)
Added a **required** dropdown on the language submission page with options: Small (< 3B), Medium (3–13B), Large (13–50B), XLarge (50–130B). The selected value is sent in the Jenkins config and appended to the PR title (e.g. `| (size:small)`).

### Required field UX
- Red asterisk and helper text indicating the field is required
- Info icon (hover + click) with details on 16-bit or lower quantization for models > 50B, Brain-Score’s 130B limit, and contacting the team for larger models

### Login background
Centered the brain background on the login/submission page across viewport sizes.

<img width="1688" height="911" alt="Screenshot 2026-03-17 at 11 39 25 AM" src="https://github.com/user-attachments/assets/d37b1cb2-a1e8-438e-a5ac-43199ec98b32" />
