### PR TITLE
Add leaderboard search as a URL parameter

### DIFF
--- a/benchmarks/tests/test_ag_grid.py
+++ b/benchmarks/tests/test_ag_grid.py
@@ -1277,3 +1277,35 @@ class TestExtraFunctionality:
         assert actual_ranks == [str(r) for r in expected_ranks], f"Ranks: {actual_ranks}"
         assert actual_models == expected_models, f"Models: {actual_models}"
         assert actual_scores == expected_scores, f"Scores: {actual_scores}"
+
+    def test_search_is_persisted_in_url_with_logical_operators(self, page):
+        """
+        Verifies that typing into the search bar writes the query (including
+        OR/AND/NOT operators) to the URL `search` param, and that loading a URL
+        with that param restores the search input value on the new page.
+        """
+        # Reset filters to default
+        page.click('#advancedFilterBtn')
+        page.evaluate("resetAllFilters()")
+        page.wait_for_timeout(2000)
+
+        # Type a query containing all supported logical operators
+        query = "alexnet OR resnet AND NOT ferguson"
+        search_input = page.locator('#modelSearchInput')
+        search_input.fill(query)
+        page.wait_for_timeout(1000)
+
+        # URL should now carry the search verbatim (URLSearchParams encodes spaces as '+')
+        current_url = page.url
+        assert "search=" in current_url, f"`search` param missing from URL: {current_url}"
+        decoded = page.evaluate(
+            "new URLSearchParams(window.location.search).get('search')"
+        )
+        assert decoded == query, f"Round-trip query mismatch: got {decoded!r}"
+
+        # Load the same URL fresh; the search input should be restored.
+        page.goto(current_url)
+        page.wait_for_selector('.ag-root', timeout=60000)
+        page.wait_for_timeout(2000)
+        restored = page.locator('#modelSearchInput').input_value()
+        assert restored == query, f"Search not restored from URL: got {restored!r}"

--- a/static/benchmarks/js/leaderboard/filters/search-filters.js
+++ b/static/benchmarks/js/leaderboard/filters/search-filters.js
@@ -82,10 +82,15 @@ function setupSearchHandlers() {
       const searchText = this.value;
       // Parse search query with logical operators (OR, AND, NOT)
       window.currentSearchQuery = parseSearchQuery(searchText);
-      
+
       // Use external filter for logical search
       if (typeof window.globalGridApi.onFilterChanged === 'function') {
         window.globalGridApi.onFilterChanged();
+      }
+
+      // Persist search to URL so the leaderboard view is shareable
+      if (typeof window.LeaderboardURLState?.updateURLFromFilters === 'function') {
+        window.LeaderboardURLState.updateURLFromFilters();
       }
     });
   }
@@ -100,6 +105,9 @@ function clearSearch() {
       window.globalGridApi.setFilterModel(null);
       window.globalGridApi.setGridOption('isExternalFilterPresent', () => false);
       window.globalGridApi.onFilterChanged();
+    }
+    if (typeof window.LeaderboardURLState?.updateURLFromFilters === 'function') {
+      window.LeaderboardURLState.updateURLFromFilters();
     }
   }
 }

--- a/static/benchmarks/js/leaderboard/navigation/url-state.js
+++ b/static/benchmarks/js/leaderboard/navigation/url-state.js
@@ -46,6 +46,10 @@ function parseURLFilters() {
   window.activeFilters.max_wayback_timestamp =
     parseFloatParam('max_wayback_timestamp') ?? defaultMax;
 
+  // Parse search query (preserves logical operators verbatim: OR, AND, NOT)
+  const searchQuery = urlParams.get('search') ?? '';
+  applySearchFromURL(searchQuery);
+
   // Apply filters to UI
   applyFiltersToUI();
 
@@ -164,6 +168,28 @@ function applyFiltersToUI() {
   }
 }
 
+// Restore search input value from URL and rebuild the parsed query the grid uses
+function applySearchFromURL(searchQuery) {
+  const searchInput = document.getElementById('modelSearchInput');
+  if (searchInput) {
+    // Set both property and attribute so the value survives cloneNode() in setupSearchHandlers
+    searchInput.value = searchQuery;
+    if (searchQuery) {
+      searchInput.setAttribute('value', searchQuery);
+    } else {
+      searchInput.removeAttribute('value');
+    }
+  }
+
+  if (window.LeaderboardSearch?.parseSearchQuery) {
+    window.currentSearchQuery = window.LeaderboardSearch.parseSearchQuery(searchQuery);
+  }
+
+  if (window.globalGridApi && typeof window.globalGridApi.onFilterChanged === 'function') {
+    window.globalGridApi.onFilterChanged();
+  }
+}
+
 // Update dropdown input with selected values
 function updateDropdownInput(filterId, selectedValues) {
   const filter = document.getElementById(filterId);
@@ -253,6 +279,13 @@ function updateURLFromFilters() {
   addRange('min_wayback_timestamp');
   addRange('max_wayback_timestamp');
 
+  // Add search query (preserves logical operators: OR, AND, NOT)
+  const searchInput = document.getElementById('modelSearchInput');
+  const searchValue = searchInput?.value?.trim();
+  if (searchValue) {
+    params.set('search', searchValue);
+  }
+
   // Add benchmark exclusions
   const excludedBenchmarks = encodeBenchmarkFilters();
   if (excludedBenchmarks) {
@@ -307,7 +340,7 @@ function hasURLFilters() {
     'public_data_only', 'runnable_only', 'excluded_benchmarks',
     'min_param_count', 'max_param_count', 'min_model_size', 'max_model_size',
     'min_score', 'max_score', 'min_stimuli_count', 'max_stimuli_count',
-    'min_ceiling', 'max_ceiling'
+    'min_ceiling', 'max_ceiling', 'search'
   ];
 
   return filterParams.some(param => params.has(param));
@@ -317,6 +350,7 @@ function hasURLFilters() {
 window.LeaderboardURLState = {
   parseURLFilters,
   applyFiltersToUI,
+  applySearchFromURL,
   updateURLFromFilters,
   encodeBenchmarkFilters,
   decodeBenchmarkFilters,


### PR DESCRIPTION
Propagates leaderboard logical search text as a URL parameter to reproduce exact leaderboard view.

### Example
```
http://localhost:8000/vision/leaderboard/?search=resnet50_imagenet_full+OR+resnet101_imagenet_full
```
OR
```
http://localhost:8000/vision/leaderboard/?min_param_count=0&max_param_count=900&min_model_size=0&max_model_size=4000&min_score=0&max_score=1&min_stimuli_count=0&max_stimuli_count=51000&min_ceiling=0&max_ceiling=1&min_wayback_timestamp=1598486400&max_wayback_timestamp=1778599885&search=resnet50_imagenet_full+OR+resnet101_imagenet_full
```
produces the following:

<img width="2666" height="1515" alt="image" src="https://github.com/user-attachments/assets/7aacec71-e4cc-421d-8c18-2f2b45f9bc58" />
