### PR TITLE
Web fix 522

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:23.10-1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY environment.yml /app/
 COPY manage.py /app/
 COPY package.json /app/
+COPY package-lock.json /app/
 COPY benchmarks /app/benchmarks
 COPY static /app/static
 COPY web /app/web
@@ -21,8 +22,8 @@ RUN echo "conda activate brain-score.web" >> ~/.bashrc
 
 SHELL ["/bin/bash", "-c"]
 
-RUN . ~/.bashrc && npm install --no-optional
-RUN . ~/.bashrc && npm install -g sass
+RUN . ~/.bashrc && npm ci --no-optional
+RUN . ~/.bashrc && npm install -g sass@1.69.5
 
 EXPOSE 80
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bulma-extensions": "^6.2.7",
     "bulma-list": "^1.2.0",
     "datatables.net-dt": "^1.10.19",
-    "sass": "^1.69.5"
+    "sass": "1.69.5"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Problem
A `sass` npm update (v1.77.0+) switched its `chokidar` dependency to ESM-only, breaking the CommonJS `require()` in the sass CLI. Django compressor runs `sass` at request time (not build time), so deployments appeared successful but every page request returned a 500.

Rolling back app versions did not help — EB rebuilds the Docker image from scratch on every deploy, so `npm install -g sass` always pulled the latest broken version regardless of which source bundle was used.

## Root cause
`Dockerfile` had two problems:
1. `npm install -g sass` — no version pin, always installed latest
2. `package-lock.json` was not copied into the image, so `npm install` also resolved to latest versions

## Fix
- Pin global sass install: `npm install -g sass@1.69.5`
- Copy `package-lock.json` into the Docker image
- Switch `npm install` → `npm ci` to enforce the lockfile
- Pin `package.json` sass entry to `1.69.5` (remove `^`)
- Pin base image to `continuumio/miniconda3:23.10-1`
