### PR TITLE
Bump miniconda3 base image (23.10-1 removed from Docker Hub)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:23.10-1
+FROM continuumio/miniconda3:24.7.1-0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \


### PR DESCRIPTION
EB deploys fail with manifest unknown error. See logs.

```
2026/06/09 09:31:53.569454 [INFO] found images [continuumio/miniconda3:23.10-1] in Dockerfile /var/app/staging/Dockerfile
2026/06/09 09:31:53.569459 [INFO] pull docker image if update is not false in Dockerrun.aws.json
2026/06/09 09:31:53.569474 [INFO] Running command: docker pull continuumio/miniconda3:23.10-1
2026/06/09 09:31:53.776264 [INFO] Error response from daemon: manifest for continuumio/miniconda3:23.10-1 not found: manifest unknown: manifest unknown

2026/06/09 09:31:53.776285 [WARN] failed to execute command: docker pull continuumio/miniconda3:23.10-1, error: Command docker pull continuumio/miniconda3:23.10-1 failed with error exit status 1. Stderr:Error response from daemon: manifest for continuumio/miniconda3:23.10-1 not found: manifest unknown: manifest unknown
, retrying...
2026/06/09 09:31:53.776294 [INFO] Running command: docker pull continuumio/miniconda3:23.10-1
2026/06/09 09:31:53.962692 [INFO] Error response from daemon: manifest for continuumio/miniconda3:23.10-1 not found: manifest unknown: manifest unknown

2026/06/09 09:31:53.962752 [ERROR] An error occurred during execution of command [app-deploy] - [Docker Specific Build Application]. Stop running the command. Error: failed to pull docker image: Command docker pull continuumio/miniconda3:23.10-1 failed with error exit status 1. Stderr:Error response from daemon: manifest for continuumio/miniconda3:23.10-1 not found: manifest unknown: manifest unknown```