### PR TITLE
Update explore page model section labels

### DIFF
--- a/benchmarks/templates/benchmarks/explore.html
+++ b/benchmarks/templates/benchmarks/explore.html
@@ -47,7 +47,7 @@
             {% endif %}
 
             <div>
-                <h3 class="title is-5">Other Models</h3>
+                <h3 class="title is-5">Full set of models</h3>
                 <div>
                     {% for model in other_models %}
                         <a class="tag model-tag" href="{% url 'model-view' domain model.id %}">{{ model.name }}</a>

--- a/benchmarks/templates/benchmarks/explore.html
+++ b/benchmarks/templates/benchmarks/explore.html
@@ -26,19 +26,19 @@
                 <h2 class="title is-title-2">{{ total_model_count }} public Models</h2>
             </div>
 
-            {% if representative_models %}
+            {% if reference_models %}
             <div class="mb-4">
                 <h3 class="title is-5">
-                    Representative Models ({{ representative_models|length }})
+                    Reference Models ({{ reference_models|length }})
                     <span class="icon is-small ml-1"
-                          data-tooltip="This curated set of 100 models includes: 10 reference models (e.g., AlexNet, CORnet-S), 8 top 2024 competition winners, 20 best neural performers (top 5 per V1, V2, V4, IT), 20 best behavioral performers, and 42 highest-scoring models by overall Brain-Score."
+                          data-tooltip="This curated set of 100 models includes: 10 canonical models (e.g., AlexNet, CORnet-S), 8 top 2024 competition winners, 20 best neural performers (top 5 per V1, V2, V4, IT), 20 best behavioral performers, and 42 highest-scoring models by overall Brain-Score."
                           data-tooltip-position="right"
                           style="cursor: help; color: #5C8DB8;">
                         <i class="fa-solid fa-circle-info"></i>
                     </span>
                 </h3>
                 <div>
-                    {% for model in representative_models %}
+                    {% for model in reference_models %}
                         <a class="tag model-tag" href="{% url 'model-view' domain model.id %}">{{ model.name }}</a>
                     {% endfor %}
                 </div>

--- a/benchmarks/views/explore.py
+++ b/benchmarks/views/explore.py
@@ -6,7 +6,7 @@ from benchmarks.models import Model, BenchmarkInstance
 def view(request, domain):
     base_query = Model.objects.filter(domain=domain, public=True)
 
-    representative_groups = [
+    reference_groups = [
         Model.Group.REFERENCE,
         Model.Group.TOP10_2024,
         Model.Group.BEST_NEURAL,
@@ -14,10 +14,10 @@ def view(request, domain):
         Model.Group.GLOBAL_SCORE,
     ]
 
-    representative_models = (base_query
-                             .filter(group__in=representative_groups)
-                             .order_by('name')
-                             .values('name', 'id'))
+    reference_models = (base_query
+                        .filter(group__in=reference_groups)
+                        .order_by('name')
+                        .values('name', 'id'))
 
     other_models = (base_query
                     .filter(group__isnull=True)
@@ -34,7 +34,7 @@ def view(request, domain):
 
     context = {
         'domain': domain,
-        'representative_models': representative_models,
+        'reference_models': reference_models,
         'other_models': other_models,
         'total_model_count': total_model_count,
         'benchmarks': benchmarks,


### PR DESCRIPTION
Updates the model section headings on the /explore page:

- "Other Models" -> "Full set of models"
- "Representative Models" -> "Reference Models" (context variable `representative_models` renamed to `reference_models` in the view and template; tooltip's "10 reference models" reworded to "10 canonical models" to avoid colliding with the new section name).