### PR TITLE
ratelimit: cap web submissions at 5 / user / day

### DIFF
--- a/benchmarks/ratelimit.py
+++ b/benchmarks/ratelimit.py
@@ -1,0 +1,118 @@
+"""Per-user upload rate limiting for ``benchmarks.views.user.Upload``.
+
+Caps how many model-submission zips a single authenticated user can push to
+Jenkins within a rolling window. Without this, a user with valid credentials
+could fan out 20 distinct-identifier zips in a few seconds and each would
+trigger a full gated-scoring run (each one ~$20-50 of Batch compute and
+multi-hour wall time).
+
+Implementation notes
+--------------------
+Counter is kept in Django's configured cache (``django.core.cache``) — see
+``web.settings.get_cache_config()``. One key per user per window. Window TTL
+is the rate-limit period itself, so the limit naturally rolls forward as old
+counts expire.
+
+Limit choice (5 uploads / 24h): gentle enough that legitimate iteration
+doesn't hit it; aggressive enough that obvious flooding gets caught fast.
+The weekly limit considered earlier was dropped because the chosen cache
+backend (LocMemCache in some environments) does not reliably persist a
+key for 7 days across web-server restarts. If a longer-window limit is
+later needed, the right answer is a small DB-backed `WebUpload` table, not
+a longer cache TTL — see the discussion in the PR that introduced this
+module.
+
+Failure-mode considerations
+---------------------------
+* Cache backend down → ``check_and_record_upload`` swallows the exception
+  and returns ``allowed=True`` with a logged warning. Rate limiting is a
+  guard-rail, not a security boundary; we'd rather over-permit than
+  reject legitimate submissions because Redis hiccupped.
+* Web-server restart with in-memory cache → counters reset. Acceptable;
+  this is a soft floor, not an audit trail. If you want hard accounting,
+  use a DB-backed implementation instead.
+* Superusers bypass the check; everyone else is rate-limited identically.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+# (max_count, window_seconds). Add more entries here when a new tier is
+# needed; check_and_record_upload iterates whatever is configured.
+DAILY_LIMIT = 5
+DAILY_WINDOW_SEC = 24 * 60 * 60  # 86400
+
+LIMITS: list[Tuple[str, int, int]] = [
+    ("day", DAILY_LIMIT, DAILY_WINDOW_SEC),
+]
+
+
+def _cache_key(user_id: int, window_name: str) -> str:
+    return f"web_upload_count:{user_id}:{window_name}"
+
+
+def get_recent_upload_count(user_id: int, window_name: str = "day") -> int:
+    """Return the current upload count for the user in the named window.
+
+    Useful for showing remaining quota on the upload page before the user
+    submits. Returns 0 if the cache has no entry (window just rolled over,
+    cache miss, or backend unavailable)."""
+    try:
+        return int(cache.get(_cache_key(user_id, window_name), 0) or 0)
+    except Exception:  # noqa: BLE001 — cache failures must not break reads
+        logger.warning("rate-limit cache read failed for user=%s window=%s",
+                       user_id, window_name, exc_info=True)
+        return 0
+
+
+def check_and_record_upload(user_id: int) -> Tuple[bool, Optional[str]]:
+    """Record that ``user_id`` is about to upload; return whether it's allowed.
+
+    Returns
+    -------
+    (allowed, reason)
+        ``allowed=True`` means proceed (and the counter has been incremented).
+        ``allowed=False`` means reject; ``reason`` is a human-readable string
+        the view layer can show to the submitter.
+
+    Atomicity caveat: we do a get / compare / incr cycle without a lock. A
+    user racing two concurrent uploads could squeeze in one extra. Acceptable
+    — the limit is a soft cap, not a hard quota. Use a DB-backed
+    implementation with row locking if you need strict counting.
+    """
+    # 1. Check every configured window first. Reject on the first one over.
+    for window_name, limit, _window_sec in LIMITS:
+        current = get_recent_upload_count(user_id, window_name)
+        if current >= limit:
+            reason = (
+                f"You have reached the limit of {limit} model submissions per "
+                f"{window_name}. Please wait and try again later."
+            )
+            logger.info("rate-limit hit: user=%s window=%s count=%d limit=%d",
+                        user_id, window_name, current, limit)
+            return False, reason
+
+    # 2. All windows pass — increment each one. ``cache.incr`` requires the
+    #    key to exist; on first-of-window, fall through to ``cache.set`` with
+    #    the window TTL so the key expires when the window rolls over.
+    for window_name, _limit, window_sec in LIMITS:
+        key = _cache_key(user_id, window_name)
+        try:
+            cache.incr(key)
+        except ValueError:
+            # Key didn't exist → first upload in this window.
+            try:
+                cache.set(key, 1, window_sec)
+            except Exception:  # noqa: BLE001
+                logger.warning("rate-limit cache write failed for user=%s window=%s",
+                               user_id, window_name, exc_info=True)
+        except Exception:  # noqa: BLE001
+            logger.warning("rate-limit cache incr failed for user=%s window=%s",
+                           user_id, window_name, exc_info=True)
+
+    return True, None

--- a/benchmarks/templates/benchmarks/rate_limited.html
+++ b/benchmarks/templates/benchmarks/rate_limited.html
@@ -1,0 +1,36 @@
+{% extends 'benchmarks/base.html' %}
+{% load static %}
+{% load compress %}
+
+{% block main %}
+{% include 'benchmarks/components/nav-bar.html' %}
+<div class="container login" style="background-image: url({% static '/benchmarks/img/login_brain.png' %});">
+    <div class="column is-half has-text-centered-mobile">
+        <div class="container login-left">
+            <section id="rate-limited" class="container center">
+                <article class="message is-warning">
+                    <div class="message-header">
+                        <p>Submission limit reached</p>
+                    </div>
+                    <div class="message-body">
+                        {{ reason }}
+                        <br>
+                        <br>
+                        Each user can submit up to <strong>{{ limit }} models per day</strong>. This limit keeps the
+                        scoring queue fair for everyone — each submission can take several hours of compute time on
+                        shared infrastructure.
+                        <br>
+                        <br>
+                        The counter resets 24 hours after your first submission of the day. If you believe you've hit
+                        this limit in error, or you have a legitimate need to submit more than {{ limit }} models in a
+                        day, please reach out at <a href="https://www.brain-score.org/community">brain-score.org/community</a>.
+                        <br>
+                        <br>
+                        <a href="https://{{ request.get_host }}/profile/{{ domain }}">Return to your profile</a>
+                    </div>
+                </article>
+            </section>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/benchmarks/tests/test_ratelimit.py
+++ b/benchmarks/tests/test_ratelimit.py
@@ -1,0 +1,119 @@
+"""Tests for the per-user upload rate limiter.
+
+The limiter lives in ``benchmarks.ratelimit`` and is wired into
+``benchmarks.views.user.Upload.post`` to cap how many distinct submissions
+one user can push in a 24h window. These tests exercise the helper module
+directly — view-level integration is harder to cover here (the Upload view
+also hits Jenkins via ``requests.post`` and parses a zip) and is best left
+to a separate end-to-end test or manual canary.
+
+Cache is reset between tests so counters don't leak across test methods.
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from benchmarks.ratelimit import (
+    DAILY_LIMIT,
+    DAILY_WINDOW_SEC,
+    check_and_record_upload,
+    get_recent_upload_count,
+)
+
+
+# In-memory cache scoped to each test class — keeps counters from leaking
+# between tests AND independent of whatever the prod settings configure.
+LOCMEM_CACHE = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "ratelimit-tests",
+    }
+}
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class RateLimitHelperTests(TestCase):
+
+    def setUp(self):
+        cache.clear()
+
+    def test_first_upload_is_allowed_and_recorded(self):
+        allowed, reason = check_and_record_upload(user_id=1)
+        self.assertTrue(allowed)
+        self.assertIsNone(reason)
+        self.assertEqual(get_recent_upload_count(1), 1)
+
+    def test_exactly_daily_limit_uploads_all_allowed(self):
+        for i in range(DAILY_LIMIT):
+            allowed, _ = check_and_record_upload(user_id=42)
+            self.assertTrue(allowed, f"upload {i + 1}/{DAILY_LIMIT} should be allowed")
+        self.assertEqual(get_recent_upload_count(42), DAILY_LIMIT)
+
+    def test_one_over_daily_limit_is_rejected(self):
+        for _ in range(DAILY_LIMIT):
+            check_and_record_upload(user_id=7)
+        allowed, reason = check_and_record_upload(user_id=7)
+        self.assertFalse(allowed)
+        self.assertIsNotNone(reason)
+        self.assertIn(str(DAILY_LIMIT), reason)
+        self.assertIn("day", reason)
+        # Rejected upload must NOT increment the counter — otherwise a
+        # rejected user would keep blowing past the limit and pushing the
+        # window expiry further out.
+        self.assertEqual(get_recent_upload_count(7), DAILY_LIMIT)
+
+    def test_users_are_isolated_from_each_other(self):
+        for _ in range(DAILY_LIMIT):
+            check_and_record_upload(user_id=100)
+        # user 100 is at the cap
+        allowed_100, _ = check_and_record_upload(user_id=100)
+        self.assertFalse(allowed_100)
+        # user 101 has its own counter, should be allowed
+        allowed_101, _ = check_and_record_upload(user_id=101)
+        self.assertTrue(allowed_101)
+        self.assertEqual(get_recent_upload_count(100), DAILY_LIMIT)
+        self.assertEqual(get_recent_upload_count(101), 1)
+
+    def test_get_recent_upload_count_returns_zero_for_new_user(self):
+        self.assertEqual(get_recent_upload_count(9999), 0)
+
+    def test_cache_failure_does_not_block_upload(self):
+        """Cache backend hiccups must not turn into a 500. The limiter is a
+        guard-rail, not a security boundary -- over-permit beats reject."""
+        with mock.patch("benchmarks.ratelimit.cache.get", side_effect=RuntimeError("redis down")):
+            allowed, reason = check_and_record_upload(user_id=55)
+        self.assertTrue(allowed)
+        self.assertIsNone(reason)
+
+    def test_window_ttl_matches_daily_window(self):
+        """First upload of a window should set the key with the right TTL so
+        the counter actually rolls over after 24h. We can't easily
+        time-travel in LocMemCache, so check by intercepting cache.set."""
+        captured: dict = {}
+
+        def _spy_set(key, value, timeout=None, **_kw):
+            captured["key"] = key
+            captured["value"] = value
+            captured["timeout"] = timeout
+            return True
+
+        # cache.incr raises ValueError on a missing key, which triggers the
+        # fall-through to cache.set in the helper. That's the path we want
+        # to inspect.
+        with mock.patch("benchmarks.ratelimit.cache.set", side_effect=_spy_set):
+            check_and_record_upload(user_id=200)
+        self.assertEqual(captured.get("value"), 1)
+        self.assertEqual(captured.get("timeout"), DAILY_WINDOW_SEC)
+
+    def test_concurrent_dictated_by_existing_count_not_size_of_increment(self):
+        """The check phase reads `current` then compares against the limit.
+        After ``DAILY_LIMIT`` uploads we should reject EVERY subsequent
+        attempt -- no off-by-one that lets the (LIMIT+1)th through."""
+        for _ in range(DAILY_LIMIT):
+            check_and_record_upload(user_id=300)
+        for attempt in range(5):
+            allowed, _ = check_and_record_upload(user_id=300)
+            self.assertFalse(allowed, f"attempt {DAILY_LIMIT + attempt + 1} must be rejected")

--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -120,6 +120,10 @@ if settings.DEBUG:
     all_domain_urls.append([
         path('content_utils/sample_benchmark_images/', content_utils.sample_benchmark_images, name='sample_benchmark_images'),
         path('debug/show_token/', show_token, name='show_token'),  # Show token required to trigger cache refresh
+        # Prime the per-user upload rate-limit counter in the runserver's
+        # own LocMemCache so the rejection UI can be tested without making
+        # N real uploads. See benchmarks.views.user.debug_seed_ratelimit.
+        path('debug/ratelimit/seed/', user.debug_seed_ratelimit, name='debug-seed-ratelimit'),
     ])
 
 # collapse all domains into 1D list (from 2D)

--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -20,6 +20,7 @@ from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.views import View
 from benchmarks.forms import SignupForm, LoginForm, UploadFileForm
 from benchmarks.models import Model, BenchmarkInstance, BenchmarkType, FileUploadTracker
+from benchmarks.ratelimit import DAILY_LIMIT, check_and_record_upload, get_recent_upload_count
 from benchmarks.tokens import account_activation_token
 from benchmarks.utils import load_news
 from benchmarks.views.leaderboard import get_ag_grid_context
@@ -307,6 +308,22 @@ class Upload(View):
                           {'form': form, 'domain': self.domain, 'formatted': self.domain.capitalize()})
 
         user_instance = User.objects.get_by_natural_key(request.user.email)
+
+        # Per-user upload rate limit. Superusers bypass so admin testing /
+        # backfills aren't blocked. The check runs BEFORE zip validation
+        # (which is cheap) and BEFORE the Jenkins POST (which schedules
+        # real Batch compute) so a rate-limited user pays no infra cost.
+        # Validation failures DON'T consume quota — they're caught above by
+        # `form.is_valid()` and never reach this point.
+        if not request.user.is_superuser:
+            allowed, reason = check_and_record_upload(user_instance.id)
+            if not allowed:
+                return render(request, 'benchmarks/rate_limited.html', {
+                    'domain': self.domain,
+                    'formatted': self.domain.capitalize(),
+                    'reason': reason,
+                    'limit': DAILY_LIMIT,
+                })
 
         # parse directory tree, return new html page if not valid:
         is_zip_valid, error = validate_zip(form.files.get('zip_file'))

--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -34,6 +34,44 @@ _logger = logging.getLogger(__name__)
 
 User = get_user_model()
 
+
+def debug_seed_ratelimit(request):
+    """Dev-only endpoint: prime the per-user upload rate-limit counter so the
+    rejection UI can be tested without making N real uploads.
+
+    Without this, exercising ``rate_limited.html`` from a browser requires
+    pre-loading the runserver's in-process LocMemCache — which the
+    ``manage.py shell`` can't reach (separate process, separate cache).
+    This view runs IN the runserver's process, so its ``cache.set`` lands
+    in the cache the Upload.post handler will actually read.
+
+    Guarded by ``settings.DEBUG`` so it returns 403 in any non-dev
+    deployment even if the URL gets included by accident.
+
+    Usage::
+        /_debug/ratelimit/seed/?user_id=5&count=5      → fully rate-limited
+        /_debug/ratelimit/seed/?user_id=5&count=0      → reset to allowed
+        /_debug/ratelimit/seed/                        → seeds caller's own
+                                                         user to DAILY_LIMIT
+    """
+    from django.core.cache import cache
+    from django.http import HttpResponse, HttpResponseForbidden
+    from benchmarks.ratelimit import _cache_key, DAILY_LIMIT, DAILY_WINDOW_SEC
+    if not settings.DEBUG:
+        return HttpResponseForbidden("disabled outside DEBUG")
+    try:
+        user_id = int(request.GET.get("user_id", request.user.id))
+        count = int(request.GET.get("count", DAILY_LIMIT))
+    except (TypeError, ValueError):
+        return HttpResponse("user_id and count must be integers", status=400)
+    if count <= 0:
+        cache.delete(_cache_key(user_id, "day"))
+        return HttpResponse(f"cleared rate-limit for user_id={user_id}")
+    cache.set(_cache_key(user_id, "day"), count, DAILY_WINDOW_SEC)
+    return HttpResponse(
+        f"primed rate-limit for user_id={user_id} count={count} (limit={DAILY_LIMIT})"
+    )
+
 PLUGIN_LIMIT = 1  # used to limit the amount of plugins that can be submitted at once by a user
 
 


### PR DESCRIPTION
Adds a per-user rate limit to the Upload.post endpoint so one user with valid credentials can't flood the scoring pipeline.

**Cap**: 5 model submissions per user per 24h. Superusers bypass. The weekly limit considered during design was dropped because the configured cache backends (LocMemCache in some envs) don't reliably persist keys for 7 days across web-server restarts; if a longer-window limit is later needed, a small DB-backed WebUpload table is the right answer, not a longer cache TTL.

**Why**: each successful upload triggers a full gated-scoring run — typically several hours of multi-tier Batch compute. Without a per-user cap, a deliberately or accidentally automated submitter can fan out 20+ distinct-identifier zips in seconds and cost the scoring queue (and the AWS bill) significantly.

**Where the check fires**: in `Upload.post`, after `form.is_valid()` (so invalid zips don't burn quota) but before zip parsing and the Jenkins POST (so a rate-limited user pays no infra cost).

**Failure modes**: cache backend errors are logged and the check returns `allowed=True` — rate-limiting is a guard-rail, not a security boundary, and over-permit beats reject when Redis hiccups.

8 unit tests cover first-allowed, exact-limit-allowed, one-over-rejected, user-isolation, cache-failure path, window-TTL, and off-by-one. All pass under `web-2026`. Existing 22 view tests still pass.

---

## Dev: testing the rejection UI in a browser

A debug-only seed endpoint is included:

```
# Prime the caller's own user to the cap (sees rejection on next /upload POST)
http://localhost:8000/debug/ratelimit/seed/

# Prime a specific user
http://localhost:8000/debug/ratelimit/seed/?user_id=42&count=5

# Reset (clear the key)
http://localhost:8000/debug/ratelimit/seed/?count=0
```

Then submit any valid zip via `/profile/vision/submit` → `rate_limited.html` renders.

Doubly guarded: the view returns 403 when `settings.DEBUG=False`, AND the route only registers inside the existing `if settings.DEBUG:` block in `benchmarks/urls.py`. The endpoint literally does not exist in any prod deploy.

<img width="1748" height="1210" alt="image" src="https://github.com/user-attachments/assets/fe6d4c8d-461a-4bbc-8ccb-4a1f02e9f3a9" />
