### PR TITLE
fix(web): accept 400 on the ALB health check via managed matcher

### DIFF
--- a/.ebextensions/05_healthcheck.config
+++ b/.ebextensions/05_healthcheck.config
@@ -1,0 +1,4 @@
+option_settings:
+  # Health checker's Host is the instance IP (not in ALLOWED_HOSTS) so Django returns 400; accept it.
+  aws:elasticbeanstalk:environment:process:default:
+    MatcherHTTPCode: "200,400"


### PR DESCRIPTION
## Problem

The ALB target-group health checker requests `GET /` with `Host` = the instance's private IP, which isn't in `ALLOWED_HOSTS`, so Django returns **400 (DisallowedHost)**. Whether the target is considered healthy then depends on the target-group **matcher**:

- **prod**: matcher `200,400` — set *directly on the target group* (unmanaged; `MatcherHTTPCode` was unset in EB config)
- **staging / dev**: EB default `200` → the 400 marked them unhealthy

This was invisible while those envs used **EC2** ASG health checks. After PR #530 switched staging to **ELB** health checks, staging's ASG began replacing the "unhealthy" instance every ~12 min (visible as a pile of terminated instances), and dev stayed Red.

## Fix

Set `MatcherHTTPCode=200,400` via the managed `aws:elasticbeanstalk:environment:process:default` namespace so **every environment** gets it consistently and prod's value stops being an unmanaged, one-off target-group tweak (which a future EB reconcile could reset to the default `200`, re-triggering the loop on prod).

## Already applied out-of-band (this PR makes it durable / version-controlled)

- staging → `200,400` (Green, churn stopped)
- dev → `200,400` (matcher fixed; dev is still down on its old pre-gunicorn version and needs a redeploy separately)
- prod → `200,400` set explicitly in EB config (no-op to the current target group, closes the reset risk)

## Note

`200,400` matches prod's established behavior. A cleaner long-term alternative is a dedicated health endpoint that returns `200` (exempt from `ALLOWED_HOSTS`) with the matcher back to `200` — larger change, deferred.
