### PR TITLE
perf(benchmarks): invalidate trend cache cross-worker via data-version

### DIFF
--- a/benchmarks/tests/test_score_trends.py
+++ b/benchmarks/tests/test_score_trends.py
@@ -172,10 +172,14 @@ class TestRankNarrative(BaseTestCase):
         self.assertTrue(lines and 'passed' in lines[0].lower(), lines)
 
     def test_clear_trend_cache_drops_all_entries(self):
-        model_views._TREND_CACHE[('public_wide', 'vision', '2026-05')] = 'sentinel'
-        model_views._TREND_CACHE[('names', 'vision', '2026-05')] = 'sentinel'
+        model_views._TREND_CACHE[('public_wide', 'vision', 12345)] = 'sentinel'
+        model_views._TREND_CACHE[('names', 'vision', 12345)] = 'sentinel'
+        # Also memoized so the recomputing process re-reads the version instead
+        # of serving the stale one until the TTL expires.
+        model_views._version_memo['vision'] = (12345, float('inf'))
         clear_trend_cache()
         self.assertEqual(model_views._TREND_CACHE, {})
+        self.assertEqual(model_views._version_memo, {})
 
     def test_rank_line_omits_benchmark_churn(self):
         """Benchmark churn is shown as separate bullets, not folded into the

--- a/benchmarks/views/model_trends.py
+++ b/benchmarks/views/model_trends.py
@@ -12,85 +12,93 @@ from ..models import Model, ModelMonthlyAggregate, MonthBenchmarkEdge, Score
 _logger = logging.getLogger(__name__)
 
 
-# Keyed on (kind, domain, max-month) so a new month naturally invalidates.
+# Cache is keyed on (kind, domain, data-version). data-version is the max
+# ModelMonthlyAggregate row id for the domain: recompute deletes and re-creates
+# each month's rows, so the max id increases on *every* run -- including a
+# same-month rerun -- and every worker (and every instance) reads that shared
+# value from the DB. So a recompute in any process invalidates all workers'
+# caches within the TTL, not just the one that ran it.
 _TREND_CACHE = {}
 _TREND_CACHE_LOCK = threading.Lock()
 
 # Hover list cap for new-leaf / coverage-completion bullets on the model card.
 _COVERAGE_BULLET_CAP = 12
 
-# The max-month lookup runs on every cache access; memoize it briefly so a
-# single page render (which touches several loaders) hits the DB once, not once
-# per loader. A new month is picked up within the TTL; recompute clears it.
-_MAX_MONTH_TTL_SECONDS = 60
-_max_month_memo = {}  # domain -> (max_month, expires_at)
+# The version lookup runs on every cache access; memoize it briefly so a single
+# page render (which touches several loaders) hits the DB once, not once per
+# loader. A recompute is picked up within the TTL; a same-process recompute
+# clears the memo immediately via clear_trend_cache().
+_VERSION_TTL_SECONDS = 60
+_version_memo = {}  # domain -> (version, expires_at)
 
 
-def _trend_cache_key(domain):
+def _trend_data_version(domain):
     now = time.time()
-    hit = _max_month_memo.get(domain)
+    hit = _version_memo.get(domain)
     if hit is not None and hit[1] > now:
         return hit[0]
-    max_month = (ModelMonthlyAggregate.objects
-                 .filter(domain=domain)
-                 .order_by('-month')
-                 .values_list('month', flat=True)
-                 .first())
-    _max_month_memo[domain] = (max_month, now + _MAX_MONTH_TTL_SECONDS)
-    return max_month
+    version = (ModelMonthlyAggregate.objects
+               .filter(domain=domain)
+               .order_by('-id')
+               .values_list('id', flat=True)
+               .first())
+    _version_memo[domain] = (version, now + _VERSION_TTL_SECONDS)
+    return version
 
 
 def _trend_cache_get(kind, domain):
-    max_month = _trend_cache_key(domain)
-    return _TREND_CACHE.get((kind, domain, max_month)), max_month
+    version = _trend_data_version(domain)
+    return _TREND_CACHE.get((kind, domain, version)), version
 
 
-def _trend_cache_put(kind, domain, max_month, value):
+def _trend_cache_put(kind, domain, version, value):
     with _TREND_CACHE_LOCK:
         for k in list(_TREND_CACHE):
             if k[0] == kind and k[1] == domain:
                 del _TREND_CACHE[k]
-        _TREND_CACHE[(kind, domain, max_month)] = value
+        _TREND_CACHE[(kind, domain, version)] = value
 
 
 def clear_trend_cache():
-    """Per-process bust. Same-month recomputes don't change ``max(month)`` so
-    natural invalidation doesn't fire; multi-worker deploys need a cross-worker
-    strategy (cache-version row, Redis pub/sub)."""
+    """Immediate local bust for the process that just recomputed. Cross-worker
+    invalidation is handled by the data-version cache key (max
+    ``ModelMonthlyAggregate`` id) -- other workers pick up the new version
+    within the TTL on their own. This just lets the recomputing process see it
+    right away instead of waiting out the TTL."""
     with _TREND_CACHE_LOCK:
         _TREND_CACHE.clear()
-    _max_month_memo.clear()
+    _version_memo.clear()
 
 
 def _load_month_benchmark_edges(domain='vision'):
     """Maps ``'YYYY-MM|YYYY-MM' -> [leaf_ids]`` newly eligible between the pair."""
-    cached, max_month = _trend_cache_get('edges', domain)
+    cached, version = _trend_cache_get('edges', domain)
     if cached is not None:
         return cached
     rows = MonthBenchmarkEdge.objects.filter(domain=domain).values(
         'month_prev', 'month_curr', 'leaf_benchmarks',
     )
     edges = {f"{r['month_prev']}|{r['month_curr']}": list(r['leaf_benchmarks'] or []) for r in rows}
-    _trend_cache_put('edges', domain, max_month, edges)
+    _trend_cache_put('edges', domain, version, edges)
     return edges
 
 
 def _load_all_months(domain):
-    cached, max_month = _trend_cache_get('all_months', domain)
+    cached, version = _trend_cache_get('all_months', domain)
     if cached is not None:
         return cached
     months = sorted({m for m in ModelMonthlyAggregate.objects
                      .filter(domain=domain)
                      .values_list('month', flat=True).distinct()})
-    _trend_cache_put('all_months', domain, max_month, months)
+    _trend_cache_put('all_months', domain, version, months)
     return months
 
 
 def _load_public_wide_scores(domain):
     """``model_id`` column + one ``YYYY-MM`` column per month, public models only."""
-    cached, max_month = _trend_cache_get('public_wide', domain)
+    cached, version = _trend_cache_get('public_wide', domain)
     if cached is not None:
-        return cached.copy(), max_month
+        return cached.copy(), version
     qs = (ModelMonthlyAggregate.objects
           .filter(domain=domain, model__public=True)
           .values('model_id', 'month', 'score'))
@@ -100,49 +108,49 @@ def _load_public_wide_scores(domain):
     else:
         wide = df.pivot(index='model_id', columns='month', values='score').reset_index()
         wide.columns.name = None
-    _trend_cache_put('public_wide', domain, max_month, wide)
-    return wide.copy(), max_month
+    _trend_cache_put('public_wide', domain, version, wide)
+    return wide.copy(), version
 
 
 def _load_public_rank_df(domain):
     """Cached public-only rank frame (same index as ``_load_public_wide_scores``).
     Recomputed only when a new month lands; the model card would otherwise rebuild
     the full model x month rank matrix on every page load."""
-    cached, max_month = _trend_cache_get('public_rank', domain)
+    cached, version = _trend_cache_get('public_rank', domain)
     if cached is not None:
-        return cached.copy(), max_month
+        return cached.copy(), version
     public_wide, _ = _load_public_wide_scores(domain)
     month_cols = [c for c in public_wide.columns if c != 'model_id']
     if not month_cols:
         rank_df = public_wide[['model_id']].copy()
     else:
         _, rank_df = wide_scores_and_rank_df(public_wide, month_cols)
-    _trend_cache_put('public_rank', domain, max_month, rank_df)
-    return rank_df.copy(), max_month
+    _trend_cache_put('public_rank', domain, version, rank_df)
+    return rank_df.copy(), version
 
 
 def _load_model_names(domain):
     """``{model_id: name}`` for all models in the domain."""
-    cached, max_month = _trend_cache_get('names', domain)
+    cached, version = _trend_cache_get('names', domain)
     if cached is not None:
-        return cached, max_month
+        return cached, version
     names = dict(Model.objects.filter(domain=domain).values_list('id', 'name'))
-    _trend_cache_put('names', domain, max_month, names)
-    return names, max_month
+    _trend_cache_put('names', domain, version, names)
+    return names, version
 
 
 def _load_focal_coverage_deltas(model_id, domain):
     """``{'YYYY-MM': [leaf_ids]}`` of leaves the focal model newly scored on
     each month. Populated by ``recompute_score_trends``."""
     kind = f'focal_coverage:{model_id}'
-    cached, max_month = _trend_cache_get(kind, domain)
+    cached, version = _trend_cache_get(kind, domain)
     if cached is not None:
         return cached
     rows = (ModelMonthlyAggregate.objects
             .filter(model_id=model_id, domain=domain)
             .values_list('month', 'coverage_leaves_added_vs_prev'))
     result = {m: (leaves or []) for m, leaves in rows}
-    _trend_cache_put(kind, domain, max_month, result)
+    _trend_cache_put(kind, domain, version, result)
     return result
 
 
@@ -159,7 +167,7 @@ def _load_focal_scored_new_leaves(model_id, domain, edges_map):
     aggregate this month, which ones did this model actually get a nonzero
     non-NaN score on by month-end?"""
     kind = f'focal_scored_new:{model_id}'
-    cached, max_month = _trend_cache_get(kind, domain)
+    cached, version = _trend_cache_get(kind, domain)
     if cached is not None:
         return cached
     result = {}
@@ -187,14 +195,14 @@ def _load_focal_scored_new_leaves(model_id, domain, edges_map):
                              if ident in earliest and earliest[ident] <= month_end})
             if scored:
                 result[curr] = scored
-    _trend_cache_put(kind, domain, max_month, result)
+    _trend_cache_put(kind, domain, version, result)
     return result # -> {'YYYY-MM': [leaf_ids]}
 
 
 def _load_new_models_by_month(domain):
     """``{'YYYY-MM': int}`` -> count of models entering the leaderboard each month
     (first non-zero MMA score lands in that month)."""
-    cached, max_month = _trend_cache_get('new_models_by_month', domain)
+    cached, version = _trend_cache_get('new_models_by_month', domain)
     if cached is not None:
         return cached
     rows = list(ModelMonthlyAggregate.objects
@@ -206,7 +214,7 @@ def _load_new_models_by_month(domain):
         df = pd.DataFrame(rows, columns=['model_id', 'month'])
         first_month = df.groupby('model_id')['month'].min()
         result = {m: int(c) for m, c in first_month.value_counts().to_dict().items()}
-    _trend_cache_put('new_models_by_month', domain, max_month, result)
+    _trend_cache_put('new_models_by_month', domain, version, result)
     return result
 
 
@@ -662,7 +670,7 @@ def load_and_build_rank_trend(model_id, domain, focal_is_public=True):
     if domain != 'vision':
         return None
     try:
-        public_wide, _max_month = _load_public_wide_scores(domain)
+        public_wide, _version = _load_public_wide_scores(domain)
         month_cols = [c for c in public_wide.columns if c != 'model_id']
         if not month_cols:
             return None


### PR DESCRIPTION
Follow-up to the historical-trends feature (PR #517), needed **before enabling the daily recompute cron**.

The in-process trend cache was keyed on `MAX(month)`, which only changes when a new month lands. A same-month recompute (new submissions mid-month) left every gunicorn worker except the one that ran it serving stale charts until a restart.

This keys the cache on `MAX(id)` of `ModelMonthlyAggregate` instead. The recompute deletes and re-creates each month's rows, so the max id increases on **every** run (including same-month reruns), and all workers read that shared value from the DB — so any recompute invalidates every worker's cache within the 60s TTL.

- No migration, no schema change.
- Verified against the dev DB: version resolves to the real `MAX(id)`, trends still build through the cache, keys carry the int version.
- Extends `test_clear_trend_cache_drops_all_entries` to cover the version-memo bust.