### PR TITLE
Blog formatting: left-align images, cap width, match tutorial card styling

### DIFF
--- a/static/benchmarks/css/blog.sass
+++ b/static/benchmarks/css/blog.sass
@@ -4,7 +4,7 @@
   display: grid
   grid-template-columns: 300px 1fr
   gap: 2rem
-  max-width: 1100px
+  max-width: 1500px
   margin: 0
   padding: 2rem
   padding-left: 0
@@ -240,14 +240,22 @@
 
 ////
 
-.blog-detail-container 
+.blog-detail-container
   display: grid
   grid-template-columns: 300px 1fr
   gap: 2rem
-  max-width: 1100px
+  max-width: 1500px
   margin: 0
   padding: 2rem
   padding-left: 0
+
+
+// Outlined card around the post reading area
+.blog-post-content
+  border: 1px solid #e0e0e0
+  border-radius: 8px
+  padding: 2rem
+  background: white
 
 
 .post-meta 

--- a/static/benchmarks/css/blog.sass
+++ b/static/benchmarks/css/blog.sass
@@ -10,10 +10,18 @@
   padding-left: 0
 
 
-.blog-post-preview 
-  margin-bottom: 3rem
-  padding-bottom: 2rem
-  border-bottom: 1px solid #eee
+// Landing-page post cards (matches the benchmark tutorial .tutorial-card)
+.blog-post-preview
+  background: #f8f9fa
+  border-radius: 8px
+  padding: 1.5rem
+  border-left: 4px solid #47b7de
+  margin-bottom: 1.5rem
+  transition: box-shadow 0.2s, transform 0.2s
+
+  &:hover
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1)
+    transform: translateY(-2px)
 
 
 .post-header h2 
@@ -250,12 +258,12 @@
   padding-left: 0
 
 
-// Outlined card around the post reading area
+// Card around the post reading area (matches the benchmark tutorial .tutorial-body)
 .blog-post-content
-  border: 1px solid #e0e0e0
-  border-radius: 8px
-  padding: 2rem
   background: white
+  padding: 2rem
+  border-radius: 8px
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1)
 
 
 .post-meta 

--- a/static/benchmarks/css/blog.sass
+++ b/static/benchmarks/css/blog.sass
@@ -4,7 +4,7 @@
   display: grid
   grid-template-columns: 300px 1fr
   gap: 2rem
-  max-width: none
+  max-width: 1100px
   margin: 0
   padding: 2rem
   padding-left: 0
@@ -244,7 +244,7 @@
   display: grid
   grid-template-columns: 300px 1fr
   gap: 2rem
-  max-width: none
+  max-width: 1100px
   margin: 0
   padding: 2rem
   padding-left: 0
@@ -308,6 +308,7 @@
 
 .post-content figure
   margin: 2rem 0
+  max-width: 720px
 
 
 .post-content figure img
@@ -315,7 +316,7 @@
   width: 100%
   max-width: 720px
   height: auto
-  margin: 0 auto
+  margin: 0
   border-radius: 8px
 
 
@@ -324,7 +325,7 @@
   font-size: 0.875rem
   line-height: 1.4
   color: #666
-  text-align: center
+  text-align: left
 
 
 // Code styling - inline code (dark red on light pink background)


### PR DESCRIPTION
- Left-align blog post images (were centered)
- Cap the blog container width at 1500px and keep it left-aligned (was full-width, text ran to the right edge)
- Style the blog to match the benchmark tutorials: the post sits in a white shadow card, and the landing-page previews are gray cards with a blue left accent
