### PR TITLE
fix(tests): preserve the shared web test database

### DIFF
--- a/benchmarks/test_runner.py
+++ b/benchmarks/test_runner.py
@@ -1,0 +1,9 @@
+from django.test.runner import DiscoverRunner
+
+
+class ExistingDatabaseTestRunner(DiscoverRunner):
+    def setup_databases(self, **kwargs):
+        return None
+
+    def teardown_databases(self, old_config, **kwargs):
+        pass

--- a/benchmarks/tests/test_score_trends.py
+++ b/benchmarks/tests/test_score_trends.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pandas as pd
 from django.conf import settings
+from django.http import Http404
 from django.test import RequestFactory
 
 from .test_views import BaseTestCase
@@ -392,8 +393,8 @@ class TestComparisonTrendEndpoint(BaseTestCase):
         runs, so the endpoint can't be used to read private models by id."""
         from benchmarks.views.compare import trend_pair
         with patch('benchmarks.views.compare.load_and_build_comparison_trend') as agg:
-            resp = trend_pair(self._get(mid_a='999999999', mid_b='888888888'), domain='vision')
-            self.assertEqual(resp.status_code, 404)
+            with self.assertRaises(Http404):
+                trend_pair(self._get(mid_a='999999999', mid_b='888888888'), domain='vision')
             agg.assert_not_called()
 
 

--- a/benchmarks/tests/test_test_runner.py
+++ b/benchmarks/tests/test_test_runner.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+
+from benchmarks.test_runner import ExistingDatabaseTestRunner
+
+
+class ExistingDatabaseTestRunnerTests(TestCase):
+    def test_database_setup_is_skipped(self):
+        runner = ExistingDatabaseTestRunner()
+
+        self.assertIsNone(runner.setup_databases())
+
+    def test_database_teardown_is_skipped(self):
+        runner = ExistingDatabaseTestRunner()
+
+        self.assertIsNone(runner.teardown_databases(None))

--- a/web/settings.py
+++ b/web/settings.py
@@ -188,6 +188,8 @@ def get_db_info():
 
 
 DATABASES = get_db_info()
+if os.getenv("DJANGO_ENV") == "test":
+    TEST_RUNNER = "benchmarks.test_runner.ExistingDatabaseTestRunner"
 
 # Cache Configuration
 # https://docs.djangoproject.com/en/4.0/topics/cache/


### PR DESCRIPTION
## Summary
- skip database setup and teardown for the shared web test database
- correct the direct-view Http404 assertion

## Test
- 76 Django tests pass, 2 skipped