### PR TITLE
feat(compare): default scatter to neural versus behavior

### DIFF
--- a/static/benchmarks/js/compare-dashboard.js
+++ b/static/benchmarks/js/compare-dashboard.js
@@ -47,6 +47,12 @@
         return Number.isFinite(number) ? number : null;
     }
 
+    function defaultComparisonBenchmarkTypes(domain) {
+        var normalizedDomain = String(domain || '').trim();
+        if (!normalizedDomain) return [];
+        return ['neural_' + normalizedDomain, 'behavior_' + normalizedDomain];
+    }
+
     function activeVersionAt(benchmark, cutoffMs) {
         var versions = (benchmark.versions || []).slice().sort(function (a, b) {
             return Number(b.version) - Number(a.version);
@@ -600,6 +606,7 @@
         activeVersionAt: activeVersionAt,
         completenessLeavesForSelection: completenessLeavesForSelection,
         dateToUtcDay: dateToUtcDay,
+        defaultComparisonBenchmarkTypes: defaultComparisonBenchmarkTypes,
         endOfUtcDay: endOfUtcDay,
         filterRowsByCompleteness: filterRowsByCompleteness,
         topRankedModelIds: topRankedModelIds,

--- a/static/benchmarks/js/compare.js
+++ b/static/benchmarks/js/compare.js
@@ -378,8 +378,15 @@ $(document).ready(function () {
         });
 
     if (window.CompareDashboard) {
-        const requestedX = window.CompareDashboard.getUrlParam('benchmark_x');
-        const requestedY = window.CompareDashboard.getUrlParam('benchmark_y');
+        const defaultBenchmarkTypes = window.CompareDashboardCore
+            ? window.CompareDashboardCore.defaultComparisonBenchmarkTypes(
+                window.compare_dashboard_data && window.compare_dashboard_data.domain
+            )
+            : [];
+        const requestedX = window.CompareDashboard.getUrlParam('benchmark_x') ||
+            defaultBenchmarkTypes[0];
+        const requestedY = window.CompareDashboard.getUrlParam('benchmark_y') ||
+            defaultBenchmarkTypes[1];
         const requestedXId = $(xlabel_selector + ' option[value="' + requestedX + '"]').length
             ? requestedX
             : window.CompareDashboard.getBenchmarkIdByTypeId(requestedX);

--- a/static/benchmarks/js/tests/compare-dashboard.test.js
+++ b/static/benchmarks/js/tests/compare-dashboard.test.js
@@ -65,6 +65,17 @@ function addLaterNeuralLeaf(data) {
     return data;
 }
 
+test('defaults benchmark comparisons to neural versus behavior', () => {
+    assert.deepEqual(
+        dashboard.defaultComparisonBenchmarkTypes('vision'),
+        ['neural_vision', 'behavior_vision']
+    );
+    assert.deepEqual(
+        dashboard.defaultComparisonBenchmarkTypes('language'),
+        ['neural_language', 'behavior_language']
+    );
+});
+
 test('uses the latest benchmark version from the first version start date', () => {
     const oldCohort = dashboard.resolveCohort(payload(), {
         asOfDate: '2021-06-01'


### PR DESCRIPTION
## Summary

- default the benchmark scatter plot to Neural versus Behavior
- resolve the aggregate pair for both Vision and Language
- preserve benchmark pairs supplied through URL parameters

## Testing

- `npm run test:compare-dashboard` (49 tests passed)
