### PR TITLE
Announce Triple-N (Li2026) benchmarks on the homepage

### DIFF
--- a/news.yaml
+++ b/news.yaml
@@ -6,6 +6,10 @@
 # identifiers). The news link auto-points to /vision/leaderboard?new=<slug>, which highlights
 # exactly those benchmarks with the "+N NEW" indicators. `leaderboard_default: false` keeps an
 # update out of the default (no-param) leaderboard view, so it only highlights when clicked.
+- date: 2026-08-04
+  text: Triple-N (Li2026) macaque electrophysiology benchmarks added
+  slug: triple-n
+  benchmarks: ["Li2026.*"]
 - date: 2026-07-31
   text: "Blog: A Leaderboard that Remembers"
   link: /blog/leaderboard_remembers/

--- a/news.yaml
+++ b/news.yaml
@@ -14,7 +14,7 @@
   text: "Blog: A Leaderboard that Remembers"
   link: /blog/leaderboard_remembers/
 - date: 2026-06-06
-  text: "LAION-fMRI (Zerbe2026) benchmarks added. More coming soon!"
+  text: LAION-fMRI (Zerbe2026) benchmarks added
   slug: laion-fmri
   benchmarks: ["Zerbe2026*"]
 - date: 2026-03-19


### PR DESCRIPTION
## Summary
Adds the homepage news entry for the **Triple-N (Li2026)** macaque electrophysiology benchmarks, merged in brain-score/vision#2412.

```yaml
- date: 2026-08-04
  text: Triple-N (Li2026) macaque electrophysiology benchmarks added
  slug: triple-n
  benchmarks: ["Li2026.*"]
```

One entry drives both surfaces, so no code change is needed:

- **Homepage news bar** — `load_news()` picks it up newest-first; it becomes the top item in `components/news-bar.html`.
- **"+N NEW" leaderboard badges** — because it carries both `slug` and `benchmarks`, `get_benchmark_updates()` promotes it to a benchmark update. `load_news` auto-derives the link `/vision/leaderboard?new=triple-n`, and `count_new_leaves_per_parent()` aggregates the matching leaf count up the ancestor chain.

`leaderboard_default` is left unset so it defaults to `True`, putting the update in the no-param leaderboard view — i.e. the benchmarks count as newly added rather than only highlighting when the news link is clicked.

## Pattern choice
`Li2026.*` rather than `Li2026*`. The existing `Allen2022*` / `Zerbe2026*` patterns match any identifier merely *starting* with those characters; including the dot removes that hazard at no cost. Verified by replicating `matches_pattern` and the leaf filter:

- **8 leaves matched** — `Li2026.{V1,V2,V4,IT}-{ridgecv,rdm}`
- 4 `Li2026.{region}` group nodes match the glob but are correctly skipped by the `number_of_all_children != 0` leaf filter
- no false positives

The count will read 8, not 12: the `Li2026.*-pls` variants are unparented by design and have never been scored, so they contribute nothing to any parent's count.

## Before this shows up
The badge counts come from the cached leaderboard context, so prod needs `refresh_all_materialized_views()` to have run and the page cache to turn over.

## Testing
YAML parsing and glob matching verified against the actual benchmark identifiers. **The rendered news bar was not visually verified** — a local dev server hit a port conflict.

## Also in this PR
Drops `More coming soon!` from the LAION-fMRI (Zerbe2026) entry now that that rollout is complete. Quoting goes with it, since the remaining text has no YAML special characters — matching the neighbouring NSD and THINGS entries.
