### PR TITLE
chore(deploy): prepare legacy dev environment retirement

### DIFF
--- a/docs/source/modules/deployment.rst
+++ b/docs/source/modules/deployment.rst
@@ -41,8 +41,8 @@ AWS and Elastic Beanstalk
      Usually, in the past, Mike has chosen either ``Environment Issue`` or ``Application Deployment Issue``.
    * Choose ``Production System Down`` for the ``Severity`` dropdown.
    * Fill in the ``Subject`` and ``Description`` fields, and attach any logs that you want (optional).
-   * For the three fields at the bottom: ``Application Name`` is ``brain-score.web``, ``Environment Name`` is the instance
-     itself (the one containing ``updated``), and ``Region`` is ``US-14-East``. Then click ``Next Step: Solve now or contact us``
+   * For the three fields at the bottom: ``Application Name`` is ``brain-score.web``, ``Environment Name`` is the target
+     environment named in the relevant deployment command below, and ``Region`` is ``US-14-East``. Then click ``Next Step: Solve now or contact us``
      at the bottom right in orange to move on to the next page.
    * Finally, click the ``Contact us`` icon in the middle of the page to open the corresponding tab, and select ``Chat``
      as the contact method. **IMPORTANT**: Add your email/whoever else needs to be looped in into the ``Additional Contacts``
@@ -54,8 +54,8 @@ Website Staging Flow/Operations (Via Command Line/PR)
 
 1. Test any changes on LocalHost to make sure they appear and function correctly.
 2. Open a PR with your changes on Brain-Score.web's GitHub.
-3. Once PR tests pass, deploy to Dev: ``eb deploy Brain-score-web-dev-updated``.
-4. Test out changes on Dev: i.e., make sure everything looks good on dev using the dev `website <https://brain-score-web-dev-updated.kmk2mcntkw.us-east-2.elasticbeanstalk.com>`_.
+3. Once PR tests pass, deploy to Dev: ``eb deploy Brain-score-web-development``.
+4. Test out changes on Dev: i.e., make sure everything looks good on dev using the dev `website <http://Brain-score-web-development.eba-e8pevjnc.us-east-2.elasticbeanstalk.com>`_.
 
    * The Dev site and LocalHost DO NOT use HTTPS, only HTTP. Do not get spooked if you get weird CSRF errors.
 5. If Dev looks good, then merge PR into master upon approval.
@@ -90,12 +90,12 @@ To Deploy (if migrations are made)
 
 1. If there are changes to Django models, make sure makemigrations has been run and the migration checked into git.
 
-2. Deploy the latest Git commit to the development environment:  ``eb deploy Brain-score-web-dev-updated --timeout 20``.
+2. Deploy the latest Git commit to the development environment:  ``eb deploy Brain-score-web-development --timeout 20``.
 
    * This can take around 15 minutes.
 3. If there are database migrations, apply them from within the container:
 
-   * ``eb ssh Brain-score-web-dev-updated``
+   * ``eb ssh Brain-score-web-development``
 
       * Reply "yes" to the fingerprint question.
       * You should get an EC2 instance prompt like ``[ec2-user@ip-172-31-32-98 ~]$``.
@@ -116,7 +116,7 @@ To Deploy (if migrations are made)
    * Exit the container:  ``exit``.
    * Exit the EC2 host:  ``exit``.
 
-4. Check the dev website:  ``Brain-score-web-dev-updated.eba-e8pevjnc.us-east-2.elasticbeanstalk.com ``.
+4. Check the dev website:  ``Brain-score-web-development.eba-e8pevjnc.us-east-2.elasticbeanstalk.com ``.
 5. If the dev website passes tests, deploy to production:  ``eb deploy brain-score-web-prod --timeout 20``.
 6. If necessary, repeat migrations, but this time begin with ``eb ssh brain-score-web-prod``.
 
@@ -128,4 +128,3 @@ If the Elastic Beanstalk environments do not exist or need to be recreated::
     eb create brain-score-web-dev -c brain-score-web-dev -r us-east-2 -p Docker --envvars DEBUG=True,DOMAIN=localhost:brain-score-web-dev.us-east-2.elasticbeanstalk.com,DB_CRED=brainscore-1-ohio-cred
 
     eb create brain-score-web-prod -c brain-score-web-prod -r us-east-2 -p Docker --envvars DEBUG=False,DOMAIN=localhost:brain-score-web-prod.us-east-2.elasticbeanstalk.com:www.brain-score.org,DB_CRED=brainscore-prod-ohio-cred
-

--- a/web/settings.py
+++ b/web/settings.py
@@ -50,7 +50,6 @@ DEBUG = os.getenv("DEBUG", "False") == "True"
 # AWS fix to add the IP of the AWS Instance to ALLOWED_HOSTS
 hosts_list = os.getenv("DOMAIN", "localhost:brain-score-web-dev.us-east-2.elasticbeanstalk.com").split(":")
 if os.getenv("DJANGO_ENV") == 'development': hosts_list.append('127.0.0.1')
-hosts_list.append("brain-score-web-dev-updated.eba-e8pevjnc.us-east-2.elasticbeanstalk.com")  # migrated dev site
 hosts_list.append("Brain-score-web-prod-updated.eba-e8pevjnc.us-east-2.elasticbeanstalk.com")  # migrated prod site
 hosts_list.append("Brain-score-web-staging.eba-e8pevjnc.us-east-2.elasticbeanstalk.com")  # staging site
 hosts_list.append("127.0.0.1")


### PR DESCRIPTION
## Summary

- make `Brain-score-web-development` the documented development target
- replace stale development deployment, SSH, and review URLs
- remove the retired environment's hard-coded Django allowed host

## Verification

- confirmed the canonical environment supplies its CNAME through `DOMAIN`
- confirmed no `Brain-score-web-dev-updated` repository references remain
- ran `python manage.py check` successfully with pre-existing warnings
- verified the canonical host remains in `ALLOWED_HOSTS`

## Infrastructure

This PR prepares the repository for retirement only. It does not terminate the
Elastic Beanstalk environment or change AWS resources.

## Post-merge infrastructure audit

- `Brain-score-web-development` is the active canonical environment: Ready,
  Green, and backed by one EC2 instance.
- `Brain-score-web-dev-updated` is Ready/Grey with suspended health, no EC2
  instances, and no active Auto Scaling group or load balancer.
- Its CloudFormation stack is already `DELETE_FAILED`; every managed resource
  is deleted except load-balancer security group `sg-0b86c6181bce1b5a7`.
- Deletion is blocked by TCP/80 ingress rule `sgr-0eeda6cfad84e5288` in orphaned
  security group `sg-034bf9a0f2f218c7d`. That group has no network interfaces,
  and its originating CloudFormation stack no longer exists.
- No references remain in Route 53, GitHub variables, GitHub secrets, GitHub
  deployment environments, AWS CodePipeline, or AWS CodeBuild.

### Remaining AWS cleanup

1. Revoke ingress rule `sgr-0eeda6cfad84e5288` from
   `sg-034bf9a0f2f218c7d`.
2. Terminate `Brain-score-web-dev-updated` through Elastic Beanstalk.
3. Verify the environment, failed CloudFormation stack, and
   `sg-0b86c6181bce1b5a7` are removed.
4. Optionally delete the now-unused orphan group `sg-034bf9a0f2f218c7d`
   after separately reviewing its remaining rules.

### Separate canonical-development issue

The canonical development CNAME currently redirects HTTP to HTTPS, but its
listener uses a certificate valid only for `brain-score.org` and
`www.brain-score.org`. A valid development DNS name/certificate or an
HTTP-only development listener is still needed for warning-free browser
review. This does not block retirement of the old environment.
