### PR TITLE
feat(compare): add benchmark matrix quick selections

### DIFF
--- a/benchmarks/templates/benchmarks/compare.html
+++ b/benchmarks/templates/benchmarks/compare.html
@@ -23,7 +23,8 @@
         var benchmark_domain_map = {{ benchmark_domain_map|safe }};
         var model_metadata = {{ model_metadata|safe }};
         var benchmark_url_map = {{ benchmark_url_map|safe }};
-        var compare_dashboard_data = {{ compare_dashboard_data|safe }};
+        var compare_dashboard_data = null;
+        var compare_dashboard_data_url = "{{ compare_dashboard_data_url|escapejs }}";
     </script>
 
     <div class="compare-layout">
@@ -43,6 +44,13 @@
                     <p class="help">These controls define the models and benchmarks used in Compare Benchmarks.</p>
                 </div>
                 <button id="compare-dashboard-reset" class="button is-small is-outlined" type="button">Reset cohort</button>
+            </div>
+
+            <div id="compare-dashboard-loading" class="notification is-light" role="status">
+                Loading comparison data&hellip;
+            </div>
+            <div id="compare-dashboard-load-error" class="notification is-danger is-light" role="alert" style="display:none;">
+                Comparison data could not be loaded. Reload the page to try again.
             </div>
 
             <div class="columns is-variable is-5 compare-dashboard-controls">

--- a/benchmarks/templates/benchmarks/compare.html
+++ b/benchmarks/templates/benchmarks/compare.html
@@ -251,6 +251,15 @@
 
             <div class="benchmark-correlation-layout">
                 <aside class="benchmark-correlation-tree-panel" aria-label="Benchmark matrix controls">
+                    <div class="benchmark-correlation-quick-selection">
+                        <label for="benchmark-correlation-preset-select">Quick selection</label>
+                        <div class="select is-small is-fullwidth">
+                            <select id="benchmark-correlation-preset-select"
+                                    aria-label="Choose a benchmark tree quick selection">
+                                <option value="">Choose a preset</option>
+                            </select>
+                        </div>
+                    </div>
                     <div class="benchmark-correlation-state-key">
                         <p><strong>Select</strong> includes a benchmark in aggregation and shows it in the matrix.</p>
                         <p><strong>Hide</strong> includes it in parent aggregation without showing it.</p>

--- a/benchmarks/tests/test_compare_dashboard.py
+++ b/benchmarks/tests/test_compare_dashboard.py
@@ -102,11 +102,32 @@ class TestCompareDashboardPayload(SimpleTestCase):
         self.assertEqual(mapping["SyntaxGym_v0"], "Engineering")
 
     @patch("benchmarks.views.compare.render")
+    @patch("benchmarks.views.compare.get_context")
+    def test_compare_view_references_dashboard_data_endpoint(self, get_context, render):
+        benchmarks = [self._benchmark("average_vision")]
+        models = [self._model(7, "example", [])]
+        get_context.return_value = {
+            "benchmarks": benchmarks,
+            "models": models,
+            "comparison_data": "[]",
+        }
+        sentinel = object()
+        render.return_value = sentinel
+
+        from benchmarks.views.compare import view
+
+        response = view(SimpleNamespace(), "vision")
+
+        self.assertIs(response, sentinel)
+        context = render.call_args.args[2]
+        metadata = json.loads(context["model_metadata"])
+        self.assertEqual(context["compare_dashboard_data_url"], "/vision/compare/data/")
+        self.assertEqual(context["comparison_data"], "[]")
+        self.assertEqual(metadata["7"]["name"], "example")
+
     @patch("benchmarks.views.compare.get_datetime_range")
     @patch("benchmarks.views.compare.get_context")
-    def test_compare_view_includes_dashboard_payload(
-        self, get_context, get_datetime_range, render
-    ):
+    def test_dashboard_data_endpoint_returns_payload(self, get_context, get_datetime_range):
         benchmarks = [self._benchmark("average_vision")]
         models = [self._model(7, "example", [])]
         get_context.return_value = {
@@ -118,16 +139,12 @@ class TestCompareDashboardPayload(SimpleTestCase):
             "min": "2020-08-27T00:00:00+00:00",
             "max": "2026-08-02T00:00:00+00:00",
         }
-        sentinel = object()
-        render.return_value = sentinel
 
-        from benchmarks.views.compare import view
+        from benchmarks.views.compare import dashboard_data
 
-        response = view(SimpleNamespace(), "vision")
+        response = dashboard_data(SimpleNamespace(method="GET"), "vision")
+        payload = json.loads(response.content)
 
-        self.assertIs(response, sentinel)
-        context = render.call_args.args[2]
-        payload = json.loads(context["compare_dashboard_data"])
-        metadata = json.loads(context["model_metadata"])
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(payload["models"][0]["id"], 7)
-        self.assertEqual(metadata["7"]["name"], "example")
+        self.assertEqual(payload["domain"], "vision")

--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -114,6 +114,8 @@ for domain in supported_domains:
         path(f'model/<str:domain>/<int:id>', partial(model.view, domain=domain), name='model-view'),
         path(f'benchmark/<str:domain>/<int:id>', partial(benchmark.view, domain=domain), name='benchmark-view'),
         path(f'{domain}/compare/', partial(compare.view, domain=domain), name='{domain}-compare'),
+        path(f'{domain}/compare/data/', partial(compare.dashboard_data, domain=domain),
+             name=f'{domain}-compare-data'),
         path(f'{domain}/compare/trend_pair/', partial(compare.trend_pair, domain=domain),
              name=f'{domain}-compare-trend-pair'),
     ]

--- a/benchmarks/views/compare.py
+++ b/benchmarks/views/compare.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from django.http import JsonResponse, HttpResponseBadRequest, Http404
 from django.shortcuts import render
+from django.urls import reverse
 from django.views.decorators.http import require_GET
 
 from .index import get_context, get_datetime_range
@@ -18,15 +19,6 @@ from ..models import FinalModelContext
 
 def view(request, domain: str):
     context = get_context(show_public=True, domain=domain)
-    datetime_range = get_datetime_range(domain=domain)
-    min_timestamp = datetime.fromisoformat(datetime_range["min"])
-    max_timestamp = datetime.fromisoformat(datetime_range["max"])
-    serialized_datetime_range = {
-        "min": datetime_range["min"],
-        "max": datetime_range["max"],
-        "min_unix": int(min_timestamp.timestamp()),
-        "max_unix": int(max_timestamp.timestamp()),
-    }
     benchmark_domain_map = _build_benchmark_domain_map(context["benchmarks"])
     context["benchmark_domain_map"] = json.dumps(benchmark_domain_map)
     context["model_metadata"] = json.dumps(
@@ -35,19 +27,38 @@ def view(request, domain: str):
     context["benchmark_url_map"] = json.dumps(
         _build_benchmark_url_map(context["benchmarks"], domain)
     )
-    context["compare_dashboard_data"] = json.dumps(
-        _build_compare_dashboard_payload(
-            context["benchmarks"],
-            context["models"],
-            domain,
-            serialized_datetime_range,
-        )
-    )
-    # The dashboard payload supersedes the legacy flat matrix on this page.
-    # Avoid sending both copies; the dashboard initializes ``comparison_data``
-    # before the existing chart modules run.
+    context["compare_dashboard_data_url"] = reverse(f'{domain}-compare-data')
+    # The dashboard payload is fetched after the page shell renders. Keep the
+    # legacy matrix empty; the dashboard initializes it when the fetch resolves.
     context["comparison_data"] = "[]"
     return render(request, 'benchmarks/compare.html', context)
+
+
+def _serialized_datetime_range(domain: str):
+    datetime_range = get_datetime_range(domain=domain)
+    min_timestamp = datetime.fromisoformat(datetime_range["min"])
+    max_timestamp = datetime.fromisoformat(datetime_range["max"])
+    return {
+        "min": datetime_range["min"],
+        "max": datetime_range["max"],
+        "min_unix": int(min_timestamp.timestamp()),
+        "max_unix": int(max_timestamp.timestamp()),
+    }
+
+
+@require_GET
+def dashboard_data(request, domain: str):
+    context = get_context(show_public=True, domain=domain)
+    payload = _build_compare_dashboard_payload(
+        context["benchmarks"],
+        context["models"],
+        domain,
+        _serialized_datetime_range(domain),
+    )
+    return JsonResponse(
+        payload,
+        json_dumps_params={"separators": (",", ":")},
+    )
 
 
 @require_GET

--- a/static/benchmarks/css/comparison.sass
+++ b/static/benchmarks/css/comparison.sass
@@ -509,6 +509,24 @@ body.compare-analysis-plot-expanded
   min-width: 0
   padding: .85rem
 
+.benchmark-correlation-quick-selection
+  align-items: center
+  border-bottom: 1px solid #dfe8e2
+  display: grid
+  gap: .6rem
+  grid-template-columns: auto minmax(0, 1fr)
+  margin-bottom: .65rem
+  padding-bottom: .65rem
+
+  label
+    color: #536159
+    font-size: .72rem
+    font-weight: 600
+
+  .select,
+  select
+    width: 100%
+
 .benchmark-correlation-state-key
   border-bottom: 1px solid #dfe8e2
   color: #536159
@@ -735,6 +753,11 @@ body.compare-analysis-plot-expanded
   display: flex
   flex-direction: column
   min-width: 0
+
+  .compare-analysis-downloads
+    align-self: stretch
+    justify-content: flex-end
+    width: 100%
 
 .benchmark-correlation-summary
   color: #3f5147

--- a/static/benchmarks/js/compare-analysis-expand.js
+++ b/static/benchmarks/js/compare-analysis-expand.js
@@ -39,31 +39,61 @@
         button.title = action;
     }
 
+    function finiteDimension(value) {
+        value = Number(value);
+        return Number.isFinite(value) && value > 0 ? value : null;
+    }
+
+    function collapsedPlotSize(plot) {
+        if (plot.__compareCollapsedSize) return plot.__compareCollapsedSize;
+        var layout = plot.layout || {};
+        var fullLayout = plot._fullLayout || {};
+        plot.__compareCollapsedSize = {
+            height: finiteDimension(layout.height) ||
+                finiteDimension(fullLayout.height) ||
+                finiteDimension(plot.clientHeight) ||
+                480,
+            width: finiteDimension(layout.width),
+            autosize: layout.autosize !== false
+        };
+        return plot.__compareCollapsedSize;
+    }
+
+    function resizeAfterRelayout(plot, plotly, browserRoot, update) {
+        function resize() {
+            var callback = function () {
+                if (plotly.Plots && plotly.Plots.resize) plotly.Plots.resize(plot);
+            };
+            if (typeof browserRoot.requestAnimationFrame === 'function') {
+                browserRoot.requestAnimationFrame(callback);
+            } else {
+                callback();
+            }
+        }
+        var relayout = plotly.relayout(plot, update);
+        if (relayout && typeof relayout.then === 'function') relayout.then(resize);
+        else resize();
+    }
+
     function resizePlots(panel, expanded, browserRoot) {
         var plotly = browserRoot.Plotly;
         if (plotly) {
             panel.querySelectorAll('.js-plotly-plot').forEach(function (plot) {
                 if (!plot.data || !plot.layout) return;
+                var original = collapsedPlotSize(plot);
                 if (expanded) {
-                    plot.__compareOriginalSize = {
-                        height: plot.layout.height,
-                        width: plot.layout.width
-                    };
-                    plotly.relayout(plot, {
+                    resizeAfterRelayout(plot, plotly, browserRoot, {
                         height: expandedPlotHeight(browserRoot.innerHeight),
-                        width: Math.max(420, plot.clientWidth || panel.clientWidth || 800),
-                        autosize: false
+                        width: null,
+                        autosize: true
                     });
                 } else {
-                    var original = plot.__compareOriginalSize || {};
-                    plotly.relayout(plot, {
-                        height: original.height === undefined ? null : original.height,
-                        width: original.width === undefined ? null : original.width,
-                        autosize: original.width === undefined
+                    resizeAfterRelayout(plot, plotly, browserRoot, {
+                        height: original.height,
+                        width: original.width,
+                        autosize: original.autosize
                     });
-                    plot.__compareOriginalSize = null;
                 }
-                if (plotly.Plots && plotly.Plots.resize) plotly.Plots.resize(plot);
             });
         }
         if (typeof browserRoot.dispatchEvent === 'function' && typeof browserRoot.Event === 'function') {
@@ -100,6 +130,7 @@
     }
 
     return {
+        collapsedPlotSize: collapsedPlotSize,
         expandIconClass: expandIconClass,
         expandedPlotHeight: expandedPlotHeight,
         initializeExpandButtons: initializeExpandButtons,

--- a/static/benchmarks/js/compare-correlation.js
+++ b/static/benchmarks/js/compare-correlation.js
@@ -38,6 +38,43 @@
         IT: true,
         behavior_vision: true
     };
+    var CORRELATION_PRESETS = [
+        {
+            id: 'rdm',
+            label: 'RDM',
+            description: 'Compare active benchmark leaves whose names contain RDM.',
+            kind: 'metric',
+            token: 'rdm'
+        },
+        {
+            id: 'ridge',
+            label: 'Ridge',
+            description: 'Compare active benchmark leaves whose names contain ridge.',
+            kind: 'metric',
+            token: 'ridge'
+        },
+        {
+            id: 'nsd-stimuli',
+            label: 'NSD stimuli',
+            description: 'Compare Allen2022, Li2026, and Zerbe2026 benchmark leaves.',
+            kind: 'families',
+            prefixes: ['allen2022', 'li2026', 'zerbe2026']
+        },
+        {
+            id: 'things-stimuli',
+            label: 'THINGS stimuli',
+            description: 'Compare Papale, Hebart fMRI, and Gifford benchmark leaves.',
+            kind: 'families',
+            prefixes: ['papale', 'hebart2023_fmri', 'gifford']
+        },
+        {
+            id: 'fmri',
+            label: 'fMRI',
+            description: 'Compare active benchmark leaves whose names contain fMRI.',
+            kind: 'metric',
+            token: 'fmri'
+        }
+    ];
 
     function buildHierarchy(benchmarks) {
         var byId = {};
@@ -98,6 +135,80 @@
                 next[benchmark.id] = DESELECT;
             } else if (activeBenchmarkIds[benchmark.id]) {
                 next[benchmark.id] = SELECT;
+            }
+        });
+        return next;
+    }
+
+    function benchmarkSearchTokens(benchmark) {
+        return [benchmark.id, benchmark.type_id, benchmark.label]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase()
+            .split(/[^a-z0-9]+/)
+            .filter(Boolean);
+    }
+
+    function benchmarkContainsToken(benchmark, token) {
+        var normalizedToken = String(token || '').toLowerCase();
+        return benchmarkSearchTokens(benchmark).some(function (candidate) {
+            return candidate.indexOf(normalizedToken) === 0;
+        });
+    }
+
+    function presetDefinition(presetId) {
+        return CORRELATION_PRESETS.find(function (preset) { return preset.id === presetId; });
+    }
+
+    function matchingPresetBenchmarkIds(presetId, benchmarks) {
+        var preset = presetDefinition(presetId);
+        if (!preset) return [];
+        var leaves = (benchmarks || []).filter(function (benchmark) {
+            return benchmark.is_leaf && !benchmark.is_engineering;
+        });
+
+        if (preset.kind === 'metric') {
+            return leaves.filter(function (benchmark) {
+                return benchmarkContainsToken(benchmark, preset.token);
+            }).map(function (benchmark) { return benchmark.id; });
+        }
+
+        if (preset.kind === 'families') {
+            return leaves.filter(function (benchmark) {
+                var typeId = String(benchmark.type_id || benchmark.label || '').toLowerCase();
+                return preset.prefixes.some(function (prefix) {
+                    return typeId.indexOf(prefix) === 0;
+                });
+            }).map(function (benchmark) { return benchmark.id; });
+        }
+
+        return [];
+    }
+
+    function getCorrelationPresets(benchmarks) {
+        return CORRELATION_PRESETS.map(function (preset) {
+            return {
+                id: preset.id,
+                label: preset.label,
+                description: preset.description,
+                benchmarkIds: matchingPresetBenchmarkIds(preset.id, benchmarks)
+            };
+        }).filter(function (preset) { return preset.benchmarkIds.length >= 2; });
+    }
+
+    function createPresetModes(presetId, benchmarks, activeBenchmarkIds) {
+        var hierarchy = buildHierarchy(benchmarks);
+        var next = {};
+        (benchmarks || []).forEach(function (benchmark) {
+            next[benchmark.id] = DESELECT;
+        });
+        matchingPresetBenchmarkIds(presetId, benchmarks).forEach(function (benchmarkId) {
+            if (!activeBenchmarkIds[benchmarkId]) return;
+            next[benchmarkId] = SELECT;
+            var parentId = hierarchy.parentById[benchmarkId];
+            while (parentId) {
+                if (!hierarchy.byId[parentId].is_engineering) next[parentId] = HIDE;
+                parentId = hierarchy.parentById[parentId];
             }
         });
         return next;
@@ -570,6 +681,7 @@
         var expand = document.getElementById('benchmark-correlation-expand');
         var selectAll = document.getElementById('benchmark-correlation-select-all');
         var reset = document.getElementById('benchmark-correlation-reset');
+        var presetSelect = document.getElementById('benchmark-correlation-preset-select');
         var downloadSvg = document.getElementById('benchmark-correlation-download-svg');
         var downloadCsv = document.getElementById('benchmark-correlation-download-csv');
         var browserRoot = document.defaultView || {};
@@ -577,6 +689,8 @@
         var latestMatrix = null;
         var relayoutHandler = null;
         var updatingTicks = false;
+        var activePresetId = null;
+        var availablePresets = getCorrelationPresets(benchmarks);
 
         benchmarks.forEach(function (benchmark) {
             var depth = 0;
@@ -631,6 +745,7 @@
                 button.setAttribute('aria-pressed', modes[benchmarkId] === mode ? 'true' : 'false');
                 if (modes[benchmarkId] === mode) button.classList.add('is-active');
                 button.addEventListener('click', function () {
+                    activePresetId = null;
                     modes = setBenchmarkMode(modes, benchmarkId, mode, hierarchy);
                     render();
                 });
@@ -653,6 +768,28 @@
             var rootList = createElement(document, 'ul', 'benchmark-correlation-tree-list is-root');
             hierarchy.roots.forEach(function (rootId) { rootList.appendChild(renderNode(rootId)); });
             treeContainer.appendChild(rootList);
+        }
+
+        function renderPresets() {
+            if (!presetSelect) return;
+            presetSelect.innerHTML = '';
+            var placeholder = createElement(document, 'option', '', 'Choose a preset');
+            placeholder.value = '';
+            presetSelect.appendChild(placeholder);
+            availablePresets.forEach(function (preset) {
+                var activeCount = preset.benchmarkIds.filter(function (benchmarkId) {
+                    return resolved.activeBenchmarkIds[benchmarkId];
+                }).length;
+                var option = createElement(
+                    document, 'option', '', preset.label + ' (' + activeCount + ')'
+                );
+                option.value = preset.id;
+                option.disabled = activeCount < 2;
+                option.title = preset.description;
+                presetSelect.appendChild(option);
+            });
+            presetSelect.value = activePresetId || '';
+            presetSelect.disabled = !availablePresets.length;
         }
 
         function renderMatrix() {
@@ -741,12 +878,22 @@
         }
 
         function render() {
+            renderPresets();
             renderTree();
             renderMatrix();
         }
 
         if (selectAll) selectAll.addEventListener('click', function () {
+            activePresetId = null;
             modes = selectAllBenchmarks(modes, benchmarks, resolved.activeBenchmarkIds);
+            render();
+        });
+        if (presetSelect) presetSelect.addEventListener('change', function () {
+            activePresetId = presetSelect.value || null;
+            if (!activePresetId) return;
+            modes = createPresetModes(
+                activePresetId, benchmarks, resolved.activeBenchmarkIds
+            );
             render();
         });
         if (downloadSvg) downloadSvg.addEventListener('click', function () {
@@ -793,11 +940,17 @@
             }
         });
         if (reset) reset.addEventListener('click', function () {
+            activePresetId = null;
             modes = createDefaultModes(benchmarks);
             render();
         });
         dashboard.subscribe(function (nextResolved) {
             resolved = nextResolved;
+            if (activePresetId) {
+                modes = createPresetModes(
+                    activePresetId, benchmarks, resolved.activeBenchmarkIds
+                );
+            }
             render();
         });
 
@@ -805,14 +958,22 @@
             getModes: function () { return Object.assign({}, modes); },
             setExpanded: setExpanded,
             selectAll: function () {
+                activePresetId = null;
                 modes = selectAllBenchmarks(modes, benchmarks, resolved.activeBenchmarkIds);
                 render();
             },
             reset: function () {
+                activePresetId = null;
                 modes = createDefaultModes(benchmarks);
                 render();
             },
+            applyPreset: function (presetId) {
+                activePresetId = presetId;
+                modes = createPresetModes(presetId, benchmarks, resolved.activeBenchmarkIds);
+                render();
+            },
             setMode: function (benchmarkId, mode) {
+                activePresetId = null;
                 modes = setBenchmarkMode(modes, benchmarkId, mode, hierarchy);
                 render();
             }
@@ -828,9 +989,12 @@
         buildHierarchy: buildHierarchy,
         buildPlotlyMatrix: buildPlotlyMatrix,
         createDefaultModes: createDefaultModes,
+        createPresetModes: createPresetModes,
         createExplorer: createExplorer,
         descendantsOf: descendantsOf,
         displayLabel: displayLabel,
+        getCorrelationPresets: getCorrelationPresets,
+        matchingPresetBenchmarkIds: matchingPresetBenchmarkIds,
         matrixColorConfig: matrixColorConfig,
         matrixTextColor: matrixTextColor,
         matrixAxisTicks: matrixAxisTicks,

--- a/static/benchmarks/js/compare-correlation.js
+++ b/static/benchmarks/js/compare-correlation.js
@@ -6,10 +6,12 @@
         module.exports = core;
     }
     root.CompareCorrelationCore = core;
+    var initialized = false;
 
     function initialize() {
-        if (!root.document || !root.CompareDashboard || !root.compare_dashboard_data) return;
+        if (initialized || !root.document || !root.CompareDashboard || !root.compare_dashboard_data) return;
         if (!root.document.getElementById('benchmark-correlation-explorer')) return;
+        initialized = true;
         root.CompareCorrelation = core.createExplorer(
             root.compare_dashboard_data,
             root.CompareDashboard,
@@ -18,6 +20,7 @@
     }
 
     if (root.document) {
+        root.document.addEventListener('compare-dashboard:ready', initialize);
         if (root.document.readyState === 'loading') {
             root.document.addEventListener('DOMContentLoaded', initialize);
         } else {
@@ -519,7 +522,118 @@
         return rows.map(function (row) { return row.map(csvValue).join(','); }).join('\n');
     }
 
-    function buildPlotlyMatrix(matrix, logoSource, maximumTicks) {
+    function paddedScatterRange(values) {
+        var minimum = Math.min.apply(null, values);
+        var maximum = Math.max.apply(null, values);
+        var span = maximum - minimum;
+        var padding = span ? span * 0.05 : Math.max(Math.abs(maximum) * 0.05, 0.05);
+        return [minimum - padding, maximum + padding];
+    }
+
+    function buildPlotlyBenchmarkScatter(points, options) {
+        options = options || {};
+        var xValues = points.map(function (point) { return point.x; });
+        var yValues = points.map(function (point) { return point.y; });
+        var xRange = paddedScatterRange(xValues);
+        var yRange = paddedScatterRange(yValues);
+        var regression = options.regression || {slope: 0, intercept: 0};
+        var regressionX = [xRange[0], xRange[1]];
+        var regressionY = regressionX.map(function (value) {
+            return regression.slope * value + regression.intercept;
+        });
+        var images = options.logoSource ? [{
+            source: options.logoSource,
+            xref: 'paper',
+            yref: 'paper',
+            x: 0.985,
+            y: 0.025,
+            sizex: 0.16,
+            sizey: 0.055,
+            xanchor: 'right',
+            yanchor: 'bottom',
+            sizing: 'contain',
+            opacity: 0.82,
+            layer: 'above'
+        }] : [];
+
+        return {
+            data: [
+                {
+                    x: regressionX,
+                    y: regressionY,
+                    type: 'scatter',
+                    mode: 'lines',
+                    line: {color: '#c8ceca', width: 2, dash: 'dot'},
+                    hoverinfo: 'skip',
+                    showlegend: false
+                },
+                {
+                    x: xValues,
+                    y: yValues,
+                    customdata: points.map(function (point) { return point.model; }),
+                    type: 'scatter',
+                    mode: 'markers',
+                    marker: {
+                        color: '#078930',
+                        opacity: 0.48,
+                        size: 11,
+                        line: {color: 'rgba(7, 137, 48, 0.22)', width: 1}
+                    },
+                    hovertemplate: '<b>%{customdata}</b>' +
+                        '<br>' + options.xLabel + ': %{x:.4f}' +
+                        '<br>' + options.yLabel + ': %{y:.4f}<extra></extra>',
+                    showlegend: false
+                }
+            ],
+            layout: {
+                title: {
+                    text: options.statsText || '',
+                    x: 0.5,
+                    xanchor: 'center',
+                    font: {size: 13, color: '#26342d'}
+                },
+                autosize: true,
+                height: options.height || 560,
+                margin: {l: 75, r: 35, t: 58, b: 70, pad: 2},
+                paper_bgcolor: '#ffffff',
+                plot_bgcolor: '#ffffff',
+                font: {family: "'Open Sans', Arial, sans-serif", color: '#26342d'},
+                hovermode: 'closest',
+                dragmode: 'zoom',
+                showlegend: false,
+                images: images,
+                xaxis: {
+                    title: {text: options.xLabel},
+                    range: xRange,
+                    automargin: true,
+                    gridcolor: '#edf1ee',
+                    zeroline: false
+                },
+                yaxis: {
+                    title: {text: options.yLabel},
+                    range: yRange,
+                    automargin: true,
+                    gridcolor: '#edf1ee',
+                    zeroline: false
+                }
+            },
+            config: {
+                responsive: true,
+                scrollZoom: true,
+                displayModeBar: true,
+                displaylogo: false,
+                modeBarButtonsToRemove: ['select2d', 'lasso2d'],
+                toImageButtonOptions: {
+                    format: 'png',
+                    filename: 'brain-score-benchmark-scatter',
+                    scale: 2
+                }
+            }
+        };
+    }
+
+    function buildPlotlyMatrix(matrix, logoSource, maximumTicks, expanded) {
+        expanded = !!expanded;
         var labels = matrix.axes.map(displayLabel);
         var indexes = labels.map(function (_label, index) { return index; });
         var ticks = matrixAxisTicks(labels, maximumTicks);
@@ -596,11 +710,11 @@
             source: logoSource,
             xref: 'paper',
             yref: 'paper',
-            x: 1.04,
+            x: expanded ? 0.98 : 1.02,
             y: 0.02,
-            sizex: 0.17,
+            sizex: 0.16,
             sizey: 0.045,
-            xanchor: 'center',
+            xanchor: expanded ? 'right' : 'left',
             yanchor: 'bottom',
             sizing: 'contain',
             opacity: 0.82,
@@ -617,7 +731,7 @@
                     font: {size: 14, color: '#26342d'}
                 },
                 autosize: true,
-                margin: {l: 90, r: 105, t: 58, b: 100, pad: 2},
+                margin: {l: 90, r: expanded ? 105 : 150, t: 58, b: 100, pad: 2},
                 paper_bgcolor: '#ffffff',
                 plot_bgcolor: '#f7faf8',
                 font: {family: 'Open Sans, Arial, sans-serif', size: 10, color: '#26342d'},
@@ -834,11 +948,13 @@
                 return;
             }
 
-            var maximumTicks = explorer && explorer.classList.contains('is-expanded') ? 48 : 24;
+            var isExpanded = explorer && explorer.classList.contains('is-expanded');
+            var maximumTicks = isExpanded ? 48 : 24;
             var plot = buildPlotlyMatrix(
                 matrix,
                 browserRoot.logo_url || '/static/benchmarks/img/logo.png',
-                maximumTicks
+                maximumTicks,
+                isExpanded
             );
             matrixContainer.setAttribute(
                 'aria-label',
@@ -985,6 +1101,7 @@
         HIDE: HIDE,
         DESELECT: DESELECT,
         aggregateRows: aggregateRows,
+        buildPlotlyBenchmarkScatter: buildPlotlyBenchmarkScatter,
         buildCorrelationMatrix: buildCorrelationMatrix,
         buildHierarchy: buildHierarchy,
         buildPlotlyMatrix: buildPlotlyMatrix,
@@ -1000,6 +1117,7 @@
         matrixAxisTicks: matrixAxisTicks,
         matrixAxisTicksForRange: matrixAxisTicksForRange,
         matrixToCsv: matrixToCsv,
+        paddedScatterRange: paddedScatterRange,
         pearsonCorrelation: pearsonCorrelation,
         selectAllBenchmarks: selectAllBenchmarks,
         setBenchmarkMode: setBenchmarkMode,

--- a/static/benchmarks/js/compare-dashboard.js
+++ b/static/benchmarks/js/compare-dashboard.js
@@ -7,10 +7,56 @@
     }
     root.CompareDashboardCore = core;
 
-    if (root.document && root.compare_dashboard_data) {
-        root.CompareDashboard = core.createDashboard(root.compare_dashboard_data, root);
-        core.initializeDashboardUi(root);
+    function setLoadState(error) {
+        if (!root.document) return;
+        var loading = root.document.getElementById('compare-dashboard-loading');
+        var failure = root.document.getElementById('compare-dashboard-load-error');
+        if (loading) loading.style.display = error ? 'none' : '';
+        if (failure) failure.style.display = error ? '' : 'none';
     }
+
+    function initialize(payload) {
+        if (!payload || root.CompareDashboard) return;
+        root.compare_dashboard_data = payload;
+        root.CompareDashboard = core.createDashboard(payload, root);
+        core.initializeDashboardUi(root);
+        setLoadState(null);
+        var loading = root.document && root.document.getElementById('compare-dashboard-loading');
+        if (loading) loading.style.display = 'none';
+        if (root.document && typeof root.CustomEvent === 'function') {
+            root.document.dispatchEvent(new root.CustomEvent(
+                'compare-dashboard:ready',
+                {detail: {dashboard: root.CompareDashboard, payload: payload}}
+            ));
+        }
+    }
+
+    function load() {
+        if (!root.document) return;
+        if (root.compare_dashboard_data) {
+            initialize(root.compare_dashboard_data);
+            return;
+        }
+        if (!root.compare_dashboard_data_url || typeof root.fetch !== 'function') {
+            setLoadState(new Error('Compare dashboard data URL is unavailable'));
+            return;
+        }
+        setLoadState(null);
+        root.fetch(root.compare_dashboard_data_url, {
+            credentials: 'same-origin',
+            headers: {'Accept': 'application/json'}
+        }).then(function (response) {
+            if (!response.ok) throw new Error('Compare dashboard request failed: ' + response.status);
+            return response.json();
+        }).then(initialize).catch(function (error) {
+            setLoadState(error);
+            if (root.console && typeof root.console.error === 'function') {
+                root.console.error('Unable to load comparison data', error);
+            }
+        });
+    }
+
+    if (root.document) load();
 }(typeof globalThis !== 'undefined' ? globalThis : this, function () {
     'use strict';
 

--- a/static/benchmarks/js/compare-model-difference-tree.js
+++ b/static/benchmarks/js/compare-model-difference-tree.js
@@ -4,10 +4,12 @@
     var core = factory();
     if (typeof module === 'object' && module.exports) module.exports = core;
     root.CompareModelDifferenceTreeCore = core;
+    var initialized = false;
 
     function initialize() {
-        if (!root.document || !root.compare_dashboard_data) return;
+        if (initialized || !root.document || !root.compare_dashboard_data) return;
         if (!root.document.getElementById('model-difference-tree-panel')) return;
+        initialized = true;
         root.CompareModelDifferenceTree = core.createDifferenceTree(
             root.compare_dashboard_data,
             root.document
@@ -15,6 +17,7 @@
     }
 
     if (root.document) {
+        root.document.addEventListener('compare-dashboard:ready', initialize);
         if (root.document.readyState === 'loading') {
             root.document.addEventListener('DOMContentLoaded', initialize);
         } else {

--- a/static/benchmarks/js/compare-stability.js
+++ b/static/benchmarks/js/compare-stability.js
@@ -7,13 +7,17 @@
         dashboardCore = require('./compare-dashboard.js');
         correlationCore = require('./compare-correlation.js');
     }
-    var core = factory(dashboardCore, correlationCore);
+    var core = factory(dashboardCore, function () {
+        return correlationCore || root.CompareCorrelationCore;
+    });
     if (typeof module === 'object' && module.exports) module.exports = core;
     root.CompareStabilityCore = core;
+    var initialized = false;
 
     function initialize() {
-        if (!root.document || !root.CompareDashboard || !root.compare_dashboard_data) return;
+        if (initialized || !root.document || !root.CompareDashboard || !root.compare_dashboard_data) return;
         if (!root.document.getElementById('benchmark-correlation-stability-panel')) return;
+        initialized = true;
         root.CompareStability = core.createStabilityPlot(
             root.compare_dashboard_data,
             root.CompareDashboard,
@@ -22,13 +26,14 @@
     }
 
     if (root.document) {
+        root.document.addEventListener('compare-dashboard:ready', initialize);
         if (root.document.readyState === 'loading') {
             root.document.addEventListener('DOMContentLoaded', initialize);
         } else {
             initialize();
         }
     }
-}(typeof globalThis !== 'undefined' ? globalThis : this, function (dashboardCore, correlationCore) {
+}(typeof globalThis !== 'undefined' ? globalThis : this, function (dashboardCore, getCorrelationCore) {
     'use strict';
 
     function stabilitySnapshotDates(minimumDate, maximumDate) {
@@ -56,6 +61,8 @@
     }
 
     function pairedCorrelation(rows, firstBenchmarkId, secondBenchmarkId) {
+        var correlationCore = getCorrelationCore();
+        if (!correlationCore) return {r: null, n: 0};
         var left = [];
         var right = [];
         (rows || []).forEach(function (row) {
@@ -76,17 +83,54 @@
             payload.datetime_range.max || new Date(Number(payload.datetime_range.max_unix) * 1000).toISOString()
         );
         return dates.map(function (date) {
-            var resolved = dashboardCore.resolveCohort(payload, {
-                asOfDate: date,
-                minimumCompleteness: options.minimumCompleteness || 0,
-                comparisonBenchmarkIds: [options.firstBenchmarkId, options.secondBenchmarkId]
-            });
-            var correlation = pairedCorrelation(
-                resolved.rows,
-                options.firstBenchmarkId,
-                options.secondBenchmarkId
-            );
-            return {date: date, r: correlation.r, n: correlation.n};
+            return stabilityPoint(payload, options, date);
+        });
+    }
+
+    function stabilityPoint(payload, options, date) {
+        var resolved = dashboardCore.resolveCohort(payload, {
+            asOfDate: date,
+            minimumCompleteness: options.minimumCompleteness || 0,
+            comparisonBenchmarkIds: [options.firstBenchmarkId, options.secondBenchmarkId]
+        });
+        var correlation = pairedCorrelation(
+            resolved.rows,
+            options.firstBenchmarkId,
+            options.secondBenchmarkId
+        );
+        return {date: date, r: correlation.r, n: correlation.n};
+    }
+
+    function buildStabilitySeriesIncrementally(payload, options, schedule, isCancelled) {
+        options = options || {};
+        var dates = options.dates || stabilitySnapshotDates(
+            payload.datetime_range.min || new Date(Number(payload.datetime_range.min_unix) * 1000).toISOString(),
+            payload.datetime_range.max || new Date(Number(payload.datetime_range.max_unix) * 1000).toISOString()
+        );
+        schedule = schedule || function (callback) { setTimeout(callback, 0); };
+        isCancelled = isCancelled || function () { return false; };
+        return new Promise(function (resolve, reject) {
+            var series = [];
+            var index = 0;
+
+            function next() {
+                if (isCancelled()) {
+                    resolve(null);
+                    return;
+                }
+                try {
+                    series.push(stabilityPoint(payload, options, dates[index]));
+                    index += 1;
+                } catch (error) {
+                    reject(error);
+                    return;
+                }
+                if (index >= dates.length) resolve(series);
+                else schedule(next);
+            }
+
+            if (!dates.length) resolve(series);
+            else schedule(next);
         });
     }
 
@@ -162,7 +206,7 @@
             ],
             layout: {
                 height: compact ? 230 : (options.expandedHeight || 640),
-                margin: compact ? {t: 8, r: 10, b: 30, l: 35} : {t: 45, r: 75, b: 65, l: 70},
+                margin: compact ? {t: 8, r: 10, b: 30, l: 35} : {t: 45, r: 95, b: 65, l: 80},
                 paper_bgcolor: '#ffffff',
                 plot_bgcolor: '#ffffff',
                 font: {family: "'Open Sans', Arial, sans-serif", color: '#26342d'},
@@ -182,22 +226,24 @@
                     gridcolor: '#edf1ee'
                 },
                 yaxis: {
-                    title: compact ? '' : 'Pearson r',
+                    title: compact ? '' : {text: 'Pearson r', standoff: 10},
                     range: [-1.05, 1.05],
                     tickmode: compact ? 'array' : 'auto',
                     tickvals: compact ? [-1, 0, 1] : undefined,
                     tickfont: compact ? {size: 9} : undefined,
                     fixedrange: compact,
+                    automargin: !compact,
                     zerolinecolor: '#cfd8d2',
                     gridcolor: '#edf1ee'
                 },
                 yaxis2: {
-                    title: compact ? '' : 'Paired models',
+                    title: compact ? '' : {text: 'Paired models', standoff: 10},
                     overlaying: 'y',
                     side: 'right',
                     rangemode: 'tozero',
                     showgrid: false,
                     showticklabels: !compact,
+                    automargin: !compact,
                     fixedrange: compact
                 },
                 shapes: options.currentDate ? [{
@@ -263,6 +309,10 @@
         var latestSeries = [];
         var latestOptions = {};
         var seriesKey = null;
+        var buildingKey = null;
+        var buildGeneration = 0;
+        var latestState = null;
+        var latestSelection = null;
         var expanded = false;
 
         function selection() {
@@ -276,27 +326,23 @@
             };
         }
 
-        function render(_resolved, state) {
-            var selected = selection();
-            if (!selected.firstBenchmarkId || !selected.secondBenchmarkId || !plotly) return;
-            var nextKey = [
-                selected.firstBenchmarkId,
-                selected.secondBenchmarkId,
-                state.minimumCompleteness
-            ].join('|');
-            if (nextKey !== seriesKey) {
-                latestSeries = buildStabilitySeries(payload, {
-                    firstBenchmarkId: selected.firstBenchmarkId,
-                    secondBenchmarkId: selected.secondBenchmarkId,
-                    minimumCompleteness: state.minimumCompleteness
-                });
-                seriesKey = nextKey;
+        function schedule(callback) {
+            if (typeof browserRoot.requestIdleCallback === 'function') {
+                browserRoot.requestIdleCallback(callback, {timeout: 100});
+            } else if (typeof browserRoot.setTimeout === 'function') {
+                browserRoot.setTimeout(callback, 0);
+            } else {
+                setTimeout(callback, 0);
             }
+        }
+
+        function draw() {
+            if (!latestState || !latestSelection || !plotly) return;
             latestOptions = {
-                firstLabel: selected.firstLabel,
-                secondLabel: selected.secondLabel,
-                minimumCompleteness: state.minimumCompleteness,
-                currentDate: state.asOfDate,
+                firstLabel: latestSelection.firstLabel,
+                secondLabel: latestSelection.secondLabel,
+                minimumCompleteness: latestState.minimumCompleteness,
+                currentDate: latestState.asOfDate,
                 logoUrl: browserRoot.logo_url,
                 compact: !expanded,
                 expandedHeight: Math.max(500, (browserRoot.innerHeight || 800) - 210)
@@ -314,6 +360,49 @@
                     if (point && point.x) dashboard.setAsOfDate(String(point.x).slice(0, 10));
                 });
                 container.__stabilityClickBound = true;
+            });
+        }
+
+        function render(_resolved, state) {
+            var selected = selection();
+            if (!selected.firstBenchmarkId || !selected.secondBenchmarkId || !plotly) return;
+            latestState = state;
+            latestSelection = selected;
+            var nextKey = [
+                selected.firstBenchmarkId,
+                selected.secondBenchmarkId,
+                state.minimumCompleteness
+            ].join('|');
+            if (nextKey === seriesKey) {
+                draw();
+                return;
+            }
+            if (nextKey === buildingKey) return;
+
+            buildingKey = nextKey;
+            var generation = ++buildGeneration;
+            if (downloadSvg) downloadSvg.disabled = true;
+            if (downloadCsv) downloadCsv.disabled = true;
+            buildStabilitySeriesIncrementally(payload, {
+                firstBenchmarkId: selected.firstBenchmarkId,
+                secondBenchmarkId: selected.secondBenchmarkId,
+                minimumCompleteness: state.minimumCompleteness
+            }, schedule, function () {
+                return generation !== buildGeneration;
+            }).then(function (series) {
+                if (!series || generation !== buildGeneration) return;
+                latestSeries = series;
+                seriesKey = nextKey;
+                buildingKey = null;
+                if (downloadSvg) downloadSvg.disabled = false;
+                if (downloadCsv) downloadCsv.disabled = false;
+                draw();
+            }).catch(function (error) {
+                if (generation !== buildGeneration) return;
+                buildingKey = null;
+                if (browserRoot.console && typeof browserRoot.console.error === 'function') {
+                    browserRoot.console.error('Unable to build correlation stability timeline', error);
+                }
             });
         }
 
@@ -374,6 +463,7 @@
     return {
         buildPlotlyStability: buildPlotlyStability,
         buildStabilitySeries: buildStabilitySeries,
+        buildStabilitySeriesIncrementally: buildStabilitySeriesIncrementally,
         compactDateTicks: compactDateTicks,
         createStabilityPlot: createStabilityPlot,
         stabilitySnapshotDates: stabilitySnapshotDates,

--- a/static/benchmarks/js/compare.js
+++ b/static/benchmarks/js/compare.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+function initializeBenchmarkComparison() {
     // adapted from http://bl.ocks.org/peterssonjonas/4a0e7cb8d23231243e0e
 
     const container_selector = "div#comparison-scatter";
@@ -10,31 +10,10 @@ $(document).ready(function () {
         return;
     }
 
-    const margin = {top: 25, right: 0, bottom: 40, left: 60};
-    let outerWidth = $(container_selector).width(),
-        outerHeight = $(container_selector).width() * 2 / 3,
-        width = outerWidth - margin.left - margin.right,
-        height = outerHeight - margin.top - margin.bottom;
-
-    const dot_size = 8,
-        color = '#078930';
-
     let idKey = "model",
         xKey = null,
         yKey = null;
-
-    let g = null,
-        xAxis = null,
-        yAxis = null;
-
-    let x = null,
-        y = null;
-
-    const svg = d3.select(container_selector)
-        .append("svg")
-        .attr("width", outerWidth)
-        .attr("height", outerHeight)
-        .attr("fill", "white");
+    const scatterElement = document.querySelector(container_selector);
 
     function currentComparisonData() {
         if (window.CompareDashboard) return window.CompareDashboard.getComparisonData();
@@ -59,40 +38,6 @@ $(document).ready(function () {
         const xValues = filtered_data.map(d => +d[xKey]);
         const yValues = filtered_data.map(d => +d[yKey]);
         return [filtered_data, xValues, yValues];
-    }
-
-    function updateRegressionLine() {
-        const [filtered_data, xValues, yValues] = getDeduplicatedValues();
-
-        const {slope, intercept} = calculateLinearRegression(xValues, yValues);
-
-        // Calculate line endpoints within the current x-axis range
-        const xStart = x.domain()[0];
-        const xEnd = x.domain()[1];
-        const yStart = slope * xStart + intercept;
-        const yEnd = slope * xEnd + intercept;
-
-        // Update the regression line with the new start and end points
-        svg.select("#regression-line")
-            .attr("x1", x(xStart))
-            .attr("y1", y(yStart))
-            .attr("x2", x(xEnd))
-            .attr("y2", y(yEnd));
-    }
-
-    function transform(d) {
-        return "translate(" + x(d[xKey]) + "," + y(d[yKey]) + ")";
-    }
-
-    function zoom() {
-        svg.select(".x.axis").call(xAxis);
-        svg.select(".y.axis").call(yAxis);
-
-        svg.selectAll(".dot")
-            .attr("transform", transform)
-            .attr("r", dot_size);
-        // Update the regression line based on zoom
-        updateRegressionLine();
     }
 
     // Calculate Pearson correlation coefficient, R^2, and p-value
@@ -155,7 +100,8 @@ $(document).ready(function () {
 
     function setEmpty(isEmpty) {
         $('#benchmark-compare-empty').toggle(isEmpty);
-        svg.style('display', isEmpty ? 'none' : null);
+        $(container_selector).toggle(!isEmpty);
+        if (isEmpty && window.Plotly && scatterElement) window.Plotly.purge(scatterElement);
     }
 
     function updatePlot() {
@@ -164,20 +110,6 @@ $(document).ready(function () {
 
         const xName = $(xlabel_selector).find('option:selected').text();
         const yName = $(ylabel_selector).find('option:selected').text();
-
-        svg.selectAll("*").remove();
-
-        // tip
-        var tip = d3.tip()
-            .attr("class", "d3-tip")
-            .offset([-10, 0])
-            .html(function (d) {
-                return "<strong>" + d[idKey] + "</strong><br>" +
-                    xName + ": " + d[xKey] + "<br>" +
-                    yName + ": " + d[yKey];
-            });
-
-        svg.call(tip);
 
         const [filtered_data, xValues, yValues] = getDeduplicatedValues();
         if (filtered_data.length < 2) {
@@ -188,115 +120,7 @@ $(document).ready(function () {
         const {correlation, rSquared, pValue} = calculateCorrelation(xValues, yValues);
         const spearman = calculateCorrelation(rankArray(xValues), rankArray(yValues));
 
-        // Calculate regression line
         const {slope, intercept} = calculateLinearRegression(xValues, yValues);
-        // Define the endpoints for the line
-        const xStart = d3.min(xValues);
-        const xEnd = d3.max(xValues);
-        const yStart = slope * xStart + intercept;
-        const yEnd = slope * xEnd + intercept;
-
-        const xMax = d3.max(filtered_data, function (d) {
-                return d[xKey];
-            }) * 1.05,
-            xMin = d3.min(filtered_data, function (d) {
-                return d[xKey];
-            }) * .95,
-            yMax = d3.max(filtered_data, function (d) {
-                return d[yKey];
-            }) * 1.05,
-            yMin = d3.min(filtered_data, function (d) {
-                return d[yKey];
-            }) * .95;
-
-        x = d3.scale.linear()
-            .range([0, width]).nice();
-
-        y = d3.scale.linear()
-            .range([height, 0]).nice();
-
-        x.domain([xMin, xMax]);
-        y.domain([yMin, yMax]);
-
-        const zoomBeh = d3.behavior.zoom()
-            .x(x)
-            .y(y)
-            .scaleExtent([0, 500])
-            .on("zoom", zoom);
-
-        g = svg
-            .append("g")
-            .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
-            .call(zoomBeh);
-
-        xAxis = d3.svg.axis()
-            .scale(x)
-            .ticks(5)
-            .orient("bottom")
-            .tickSize(-height);
-
-        yAxis = d3.svg.axis()
-            .scale(y)
-            .ticks(3)
-            .orient("left")
-            .tickSize(-width);
-
-        g.append("rect")
-            .attr("width", width)
-            .attr("height", height);
-
-        g.append("g")
-            .classed("x axis", true)
-            .attr("transform", "translate(0," + height + ")")
-            .call(xAxis)
-            .append("text")
-            .attr("class", "label")
-            .attr("x", width / 2)
-            .attr("y", 35)
-            .style("text-anchor", "middle")
-            .style("fill", "black")
-            .style("font-size", "14px")
-            .style("font-family", "'Open Sans', Arial, sans-serif")
-            .style("font-weight", "400")
-            .text(xName);
-
-        svg.selectAll(".x.axis text")
-            .style("fill", "black")
-            .style("font-family", "'Open Sans', Arial, sans-serif")
-            .style("font-weight", "400")
-            .style("font-size", "12px");
-
-        // Restore axis label size (selectAll above set ticks to 12px)
-        svg.select(".x.axis .label")
-            .style("font-size", "14px");
-
-        g.append("g")
-            .classed("y axis", true)
-            .call(yAxis)
-            .append("text")
-            .attr("class", "label")
-            .attr("transform", "rotate(-90)")
-            .attr("x", -height / 2)
-            .attr("y", -50)
-            .attr("dy", ".71em")
-            .style("text-anchor", "middle")
-            .style("fill", "black")
-            .style("font-size", "14px")
-            .style("font-family", "'Open Sans', Arial, sans-serif")
-            .style("font-weight", "400")
-            .text(yName);
-
-        svg.selectAll(".y.axis text")
-            .style("fill", "black")
-            .style("font-family", "'Open Sans', Arial, sans-serif")
-            .style("font-weight", "400")
-            .style("font-size", "12px");
-
-        svg.select(".y.axis .label")
-            .style("font-size", "14px");
-
-        // Correlation stats -- centered above the plot
-        var statsFont = "'Open Sans', Arial, sans-serif";
         var pValueStr = pValue === null ? 'p-value: N/A' : (pValue >= 0.01
             ? `p-value: ${pValue.toFixed(2)}`
             : `p-value: ${pValue.toExponential(1).replace(/^(\d)\.?\d*e/, '$1e')}`);
@@ -305,52 +129,21 @@ $(document).ready(function () {
             + "    R\u00B2: " + (rSquared === null ? 'N/A' : rSquared.toFixed(2))
             + "    " + pValueStr
             + "    n=" + filtered_data.length + " paired models";
-
-        g.append("text")
-            .attr("class", "stats-text")
-            .attr("x", width / 2)
-            .attr("y", -8)
-            .attr("fill", "black")
-            .style("font-size", "14px")
-            .style("font-family", statsFont)
-            .style("font-weight", "400")
-            .style("text-anchor", "middle")
-            .text(statsText);
-
-        // plot regression line
-        g.append("line")
-            .attr("id", "regression-line")
-            .attr("x1", x(xStart))
-            .attr("y1", y(yStart))
-            .attr("x2", x(xEnd))
-            .attr("y2", y(yEnd))
-            .attr("stroke-width", 2)
-            .attr("stroke", "lightgrey")
-            .attr("stroke-dasharray", "4,4");
-
-
-        const objects = g.append("svg")
-            .classed("objects", true)
-            .attr("width", width)
-            .attr("height", height);
-
-        objects.selectAll(".dot")
-            .data(filtered_data)
-            .enter().append("circle")
-            .classed("dot", true)
-            .attr("r", dot_size)
-            .attr("transform", transform)
-            .style("fill", color)
-            .on("mouseover", tip.show)
-            .on("mouseout", tip.hide);
-
-        // add Brain-Score logo (bottom-right corner)
-        g.append("svg:image")
-            .attr('x', width - 125)
-            .attr('y', height - 33)
-            .attr('width', 120)
-            .attr('height', 28)
-            .attr("xlink:href", logo_url);
+        if (!window.Plotly || !window.CompareCorrelationCore) return;
+        const plot = window.CompareCorrelationCore.buildPlotlyBenchmarkScatter(
+            filtered_data.map(function (row) {
+                return {model: row[idKey], x: Number(row[xKey]), y: Number(row[yKey])};
+            }),
+            {
+                xLabel: xName,
+                yLabel: yName,
+                statsText: statsText,
+                regression: {slope: slope, intercept: intercept},
+                logoSource: window.logo_url || '/static/benchmarks/img/logo.png',
+                height: Math.max(480, Math.min(760, Math.round($(container_selector).width() * 2 / 3)))
+            }
+        );
+        window.Plotly.react(scatterElement, plot.data, plot.layout, plot.config);
     }
 
     function syncComparisonBenchmarks() {
@@ -404,21 +197,13 @@ $(document).ready(function () {
 
     updatePlot();
 
-    // Redraw at the container's current width on resize so the chart tracks the
-    // layout instead of freezing at load-time size. Skip while the panel is
-    // hidden (width 0) to avoid collapsing the chart.
     let _cmpResizeTimer = null;
     $(window).on('resize', function () {
         clearTimeout(_cmpResizeTimer);
         _cmpResizeTimer = setTimeout(function () {
-            const w = $(container_selector).width();
-            if (!w || w < 50) return;
-            outerWidth = w;
-            outerHeight = w * 2 / 3;
-            width = outerWidth - margin.left - margin.right;
-            height = outerHeight - margin.top - margin.bottom;
-            svg.attr("width", outerWidth).attr("height", outerHeight);
-            updatePlot();
+            if (window.Plotly && window.Plotly.Plots && scatterElement) {
+                window.Plotly.Plots.resize(scatterElement);
+            }
         }, 200);
     });
 
@@ -461,16 +246,6 @@ $(document).ready(function () {
 
     // download functionality
 
-    function inlineStyles(element) {
-        const cssStyles = window.getComputedStyle(element);
-        for (let i = 0; i < cssStyles.length; i++) {
-            const styleName = cssStyles[i];
-            element.style[styleName] = cssStyles.getPropertyValue(styleName);
-        }
-
-        Array.from(element.children).forEach(child => inlineStyles(child));
-    }
-
     function getFileName(extension) {
         let xlabel = $(xlabel_selector).find('option:selected').text();
         let ylabel = $(ylabel_selector).find('option:selected').text();
@@ -478,25 +253,16 @@ $(document).ready(function () {
     }
 
     $("#downloadSVGButton").click(function () {
-        const svgNode = d3.select('svg').node();
-        const clonedSvg = svgNode.cloneNode(true);
-        inlineStyles(clonedSvg);
-        let svgData = clonedSvg.outerHTML;
-        svgData = svgData.replace('xlink:href="/static/benchmarks/img/logo.png"',
-            'xlink:href="' + window.location.origin + '/static/benchmarks/img/logo.png"')
-        const svgBlob = new Blob([svgData], {type: "image/svg+xml;charset=utf-8"});
-
-        const downloadLink = document.createElement("a");
-        downloadLink.href = URL.createObjectURL(svgBlob);
-        downloadLink.download = getFileName(".svg");
-        document.body.appendChild(downloadLink);
-        downloadLink.click();
-        document.body.removeChild(downloadLink);
+        if (!window.Plotly || !scatterElement) return;
+        window.Plotly.downloadImage(scatterElement, {
+            format: 'svg',
+            filename: getFileName('')
+        });
     });
 
     function makeCSV() {
         // only data for selected benchmarks
-        [filtered_data, x, y] = getDeduplicatedValues();
+        const [filtered_data] = getDeduplicatedValues();
         const fields = ['model', xKey, yKey];
         const headers = [
             'model',
@@ -551,4 +317,9 @@ $(document).ready(function () {
     });
     $(xlabel_selector + ', ' + ylabel_selector).on('change', syncComparisonExampleSelection);
     syncComparisonExampleSelection();
+}
+
+$(document).ready(function () {
+    if (window.CompareDashboard) initializeBenchmarkComparison();
+    else document.addEventListener('compare-dashboard:ready', initializeBenchmarkComparison, {once: true});
 });

--- a/static/benchmarks/js/compare_models.js
+++ b/static/benchmarks/js/compare_models.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+function initializeModelComparison() {
     // Guard: only run on the model compare page
     if (document.getElementById('scatter-plot') === null) {
         return;
@@ -963,4 +963,9 @@ $(document).ready(function () {
             updateAllCharts();
         }, 220);
     });
+}
+
+$(document).ready(function () {
+    if (window.CompareDashboard) initializeModelComparison();
+    else document.addEventListener('compare-dashboard:ready', initializeModelComparison, {once: true});
 });

--- a/static/benchmarks/js/tests/compare-analysis-expand.test.js
+++ b/static/benchmarks/js/tests/compare-analysis-expand.test.js
@@ -18,3 +18,40 @@ test('leaves useful plot height while enforcing a minimum', () => {
     assert.equal(expand.expandedPlotHeight(1000), 770);
     assert.equal(expand.expandedPlotHeight(600), 480);
 });
+
+test('preserves the original collapsed size across repeated toggles', () => {
+    const plot = {
+        data: [{}],
+        layout: {height: 620, autosize: true},
+        _fullLayout: {height: 620},
+        clientHeight: 620
+    };
+    const updates = [];
+    const plotly = {
+        relayout(_plot, update) {
+            updates.push(update);
+            _plot.layout.height = update.height;
+            _plot.layout.width = update.width;
+            _plot.layout.autosize = update.autosize;
+        },
+        Plots: {resize() {}}
+    };
+    const panel = {querySelectorAll() { return [plot]; }};
+    const browserRoot = {
+        Plotly: plotly,
+        innerHeight: 1000,
+        requestAnimationFrame(callback) { callback(); }
+    };
+
+    expand.resizePlots(panel, true, browserRoot);
+    expand.resizePlots(panel, false, browserRoot);
+    expand.resizePlots(panel, true, browserRoot);
+    expand.resizePlots(panel, false, browserRoot);
+
+    assert.equal(updates[0].height, 770);
+    assert.equal(updates[1].height, 620);
+    assert.equal(updates[2].height, 770);
+    assert.equal(updates[3].height, 620);
+    assert.equal(updates[1].autosize, true);
+    assert.equal(updates[3].width, null);
+});

--- a/static/benchmarks/js/tests/compare-correlation.test.js
+++ b/static/benchmarks/js/tests/compare-correlation.test.js
@@ -56,6 +56,30 @@ function languageBenchmarks() {
     ];
 }
 
+function presetBenchmarks() {
+    return [
+        {id: 'average_vision_v0', type_id: 'average_vision', label: 'average_vision', parent_id: null, is_leaf: false, is_engineering: false},
+        {id: 'neural_vision_v0', type_id: 'neural_vision', label: 'neural_vision', parent_id: 'average_vision_v0', is_leaf: false, is_engineering: false},
+        {id: 'V1_v0', type_id: 'V1', label: 'V1', parent_id: 'neural_vision_v0', is_leaf: false, is_engineering: false},
+        {id: 'Allen2022_fmri_surface.V1_v0', type_id: 'Allen2022_fmri_surface.V1', label: 'Allen2022_fmri_surface.V1', parent_id: 'V1_v0', is_leaf: false, is_engineering: false},
+        {id: 'Allen2022_fmri_surface.V1-rdm_v1', type_id: 'Allen2022_fmri_surface.V1-rdm', label: 'Allen2022_fmri_surface.V1-rdm', parent_id: 'Allen2022_fmri_surface.V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Allen2022_fmri_surface.V1-ridge_v1', type_id: 'Allen2022_fmri_surface.V1-ridge', label: 'Allen2022_fmri_surface.V1-ridge', parent_id: 'Allen2022_fmri_surface.V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Li2026.V1_v0', type_id: 'Li2026.V1', label: 'Li2026.V1', parent_id: 'V1_v0', is_leaf: false, is_engineering: false},
+        {id: 'Li2026.V1-rdm_v1', type_id: 'Li2026.V1-rdm', label: 'Li2026.V1-rdm', parent_id: 'Li2026.V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Li2026.V1-ridgecv_v1', type_id: 'Li2026.V1-ridgecv', label: 'Li2026.V1-ridgecv', parent_id: 'Li2026.V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Zerbe2026_fmri.V1_v0', type_id: 'Zerbe2026_fmri.V1', label: 'Zerbe2026_fmri.V1', parent_id: 'V1_v0', is_leaf: false, is_engineering: false},
+        {id: 'Zerbe2026_fmri.V1-rdm-pearson_v1', type_id: 'Zerbe2026_fmri.V1-rdm-pearson', label: 'Zerbe2026_fmri.V1-rdm-pearson', parent_id: 'Zerbe2026_fmri.V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Zerbe2026_fmri.V1-ood-ridgecv_v1', type_id: 'Zerbe2026_fmri.V1-ood-ridgecv', label: 'Zerbe2026_fmri.V1-ood-ridgecv', parent_id: 'Zerbe2026_fmri.V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Zerbe2026_fmri.V1-tau-ridgecv_v1', type_id: 'Zerbe2026_fmri.V1-tau-ridgecv', label: 'Zerbe2026_fmri.V1-tau-ridgecv', parent_id: 'Zerbe2026_fmri.V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'tong.Coggan2024_fMRI.V1-rdm_v1', type_id: 'tong.Coggan2024_fMRI.V1-rdm', label: 'tong.Coggan2024_fMRI.V1-rdm', parent_id: 'V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Hebart2023_fmri.V1-ridgecv_v1', type_id: 'Hebart2023_fmri.V1-ridgecv', label: 'Hebart2023_fmri.V1-ridgecv', parent_id: 'V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Papale2025.V1-ridgecv_v1', type_id: 'Papale2025.V1-ridgecv', label: 'Papale2025.V1-ridgecv', parent_id: 'V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'Gifford2022.IT-ridgecv_v1', type_id: 'Gifford2022.IT-ridgecv', label: 'Gifford2022.IT-ridgecv', parent_id: 'V1_v0', is_leaf: true, is_engineering: false},
+        {id: 'engineering_vision_v0', type_id: 'engineering_vision', label: 'engineering_vision', parent_id: null, is_leaf: false, is_engineering: true},
+        {id: 'engineering-rdm_v1', type_id: 'engineering-rdm', label: 'Engineering RDM', parent_id: 'engineering_vision_v0', is_leaf: true, is_engineering: true}
+    ];
+}
+
 test('defaults to neural, region, and behavioral axes and deselects engineering', () => {
     const items = benchmarks();
     const modes = correlation.createDefaultModes(items);
@@ -95,6 +119,63 @@ test('select all includes active non-engineering benchmarks only', () => {
     assert.equal(modes['v1-b_v0'], correlation.HIDE);
     assert.equal(modes['engineering_vision_v0'], correlation.DESELECT);
     assert.equal(modes['engineering-a_v0'], correlation.DESELECT);
+});
+
+test('metric and stimulus presets discover matching benchmark leaves by name', () => {
+    const items = presetBenchmarks();
+    items.push({
+        id: 'FutureStudy.V1-rdm_cv_v1',
+        type_id: 'FutureStudy.V1-rdm_cv',
+        label: 'FutureStudy.V1-rdm_cv',
+        parent_id: 'V1_v0',
+        is_leaf: true,
+        is_engineering: false
+    });
+
+    const rdm = correlation.matchingPresetBenchmarkIds('rdm', items);
+    const ridge = correlation.matchingPresetBenchmarkIds('ridge', items);
+    const nsd = correlation.matchingPresetBenchmarkIds('nsd-stimuli', items);
+    const things = correlation.matchingPresetBenchmarkIds('things-stimuli', items);
+
+    assert.ok(rdm.includes('FutureStudy.V1-rdm_cv_v1'));
+    assert.equal(rdm.includes('engineering-rdm_v1'), false);
+    assert.ok(ridge.includes('Zerbe2026_fmri.V1-ood-ridgecv_v1'));
+    assert.deepEqual(nsd, [
+        'Allen2022_fmri_surface.V1-rdm_v1',
+        'Allen2022_fmri_surface.V1-ridge_v1',
+        'Li2026.V1-rdm_v1',
+        'Li2026.V1-ridgecv_v1',
+        'Zerbe2026_fmri.V1-rdm-pearson_v1',
+        'Zerbe2026_fmri.V1-ood-ridgecv_v1',
+        'Zerbe2026_fmri.V1-tau-ridgecv_v1'
+    ]);
+    assert.deepEqual(things, [
+        'Hebart2023_fmri.V1-ridgecv_v1',
+        'Papale2025.V1-ridgecv_v1',
+        'Gifford2022.IT-ridgecv_v1'
+    ]);
+    assert.equal(
+        correlation.getCorrelationPresets(items)
+            .some(preset => preset.id === 'rdm-ridge-pairs'),
+        false
+    );
+});
+
+test('preset modes select active matches, hide ancestors, and deselect everything else', () => {
+    const items = presetBenchmarks();
+    const active = activeBenchmarks(items);
+    active['Li2026.V1-rdm_v1'] = false;
+    const modes = correlation.createPresetModes('rdm', items, active);
+
+    assert.equal(modes['Allen2022_fmri_surface.V1-rdm_v1'], correlation.SELECT);
+    assert.equal(modes['Allen2022_fmri_surface.V1_v0'], correlation.HIDE);
+    assert.equal(modes.V1_v0, correlation.HIDE);
+    assert.equal(modes.neural_vision_v0, correlation.HIDE);
+    assert.equal(modes.average_vision_v0, correlation.HIDE);
+    assert.equal(modes['Li2026.V1-rdm_v1'], correlation.DESELECT);
+    assert.equal(modes['Allen2022_fmri_surface.V1-ridge_v1'], correlation.DESELECT);
+    assert.equal(modes.engineering_vision_v0, correlation.DESELECT);
+    assert.equal(modes['engineering-rdm_v1'], correlation.DESELECT);
 });
 
 test('deselect cascades and selecting a child restores deselected ancestors', () => {

--- a/static/benchmarks/js/tests/compare-correlation.test.js
+++ b/static/benchmarks/js/tests/compare-correlation.test.js
@@ -253,6 +253,38 @@ test('uses finite pairwise scores including zero and enforces minimum overlap', 
     assert.deepEqual(unsupported, {r: null, n: 9});
 });
 
+test('builds an interactive branded benchmark scatter plot', () => {
+    const plot = correlation.buildPlotlyBenchmarkScatter([
+        {model: 'model-a', x: 0.2, y: 0.3},
+        {model: 'model-b', x: 0.7, y: 0.8}
+    ], {
+        xLabel: 'Neural',
+        yLabel: 'Behavioral',
+        statsText: 'Pearson R: 1.00',
+        regression: {slope: 1, intercept: 0.1},
+        logoSource: '/static/logo.png',
+        height: 520
+    });
+
+    assert.equal(plot.data[1].type, 'scatter');
+    assert.equal(plot.data[1].mode, 'markers');
+    assert.deepEqual(plot.data[1].customdata, ['model-a', 'model-b']);
+    assert.equal(plot.layout.xaxis.title.text, 'Neural');
+    assert.equal(plot.layout.yaxis.title.text, 'Behavioral');
+    assert.equal(plot.layout.height, 520);
+    assert.equal(plot.layout.images[0].source, '/static/logo.png');
+    assert.ok(plot.layout.images[0].x <= 1);
+    assert.equal(plot.layout.images[0].xanchor, 'right');
+    assert.equal(plot.config.displayModeBar, true);
+    assert.equal(plot.config.scrollZoom, true);
+    assert.equal(plot.config.toImageButtonOptions.format, 'png');
+});
+
+test('pads constant score ranges so scatter axes remain visible', () => {
+    assert.deepEqual(correlation.paddedScatterRange([0, 0]), [-0.05, 0.05]);
+    assert.deepEqual(correlation.paddedScatterRange([1, 1]), [0.95, 1.05]);
+});
+
 test('starts a positive-only Plotly color scale at the lowest correlation', () => {
     const matrix = {
         axes: benchmarks().slice(0, 2),
@@ -273,7 +305,9 @@ test('starts a positive-only Plotly color scale at the lowest correlation', () =
         [1, '#078930']
     ]);
     assert.equal(plot.layout.images[0].source, '/static/logo.png');
-    assert.equal(plot.layout.images[0].x, 1.04);
+    assert.equal(plot.layout.images[0].x, 1.02);
+    assert.equal(plot.layout.images[0].xanchor, 'left');
+    assert.equal(plot.layout.margin.r, 150);
     assert.ok(plot.layout.images[0].y < 0.1);
     assert.equal(plot.config.displayModeBar, true);
     assert.equal(
@@ -282,6 +316,23 @@ test('starts a positive-only Plotly color scale at the lowest correlation', () =
     );
     assert.equal('width' in plot.config.toImageButtonOptions, false);
     assert.equal('height' in plot.config.toImageButtonOptions, false);
+});
+
+test('keeps the expanded matrix logo inside the plot boundary', () => {
+    const matrix = {
+        axes: benchmarks().slice(0, 2),
+        cells: [
+            [{r: 1, n: 10}, {r: 0.25, n: 9}],
+            [{r: 0.25, n: 9}, {r: 1, n: 10}]
+        ],
+        modelCount: 10,
+        minimumOverlap: 8
+    };
+    const plot = correlation.buildPlotlyMatrix(matrix, '/static/logo.png', 48, true);
+
+    assert.equal(plot.layout.images[0].x, 0.98);
+    assert.equal(plot.layout.images[0].xanchor, 'right');
+    assert.equal(plot.layout.margin.r, 105);
 });
 
 test('uses the full Pearson color range when the matrix contains negatives', () => {

--- a/static/benchmarks/js/tests/compare-dashboard.test.js
+++ b/static/benchmarks/js/tests/compare-dashboard.test.js
@@ -327,3 +327,51 @@ test('initializes the UI after a deferred script creates the dashboard API', () 
     assert.equal(elements['compare-wayback-value'].textContent, '2026-08-03');
     assert.equal(elements['compare-wayback-min-label'].textContent, '2020-08-27');
 });
+
+test('fetches dashboard data and announces when asynchronous initialization completes', async () => {
+    const elements = {
+        'compare-dashboard': {style: {}, addEventListener() {}},
+        'compare-dashboard-loading': {style: {}},
+        'compare-dashboard-load-error': {style: {}},
+        'compare-dashboard-empty': {style: {}},
+        'compare-completeness-histogram': {style: {}, innerHTML: ''}
+    };
+    const events = [];
+    const context = {
+        compare_dashboard_data: null,
+        compare_dashboard_data_url: '/vision/compare/data/',
+        document: {
+            readyState: 'interactive',
+            getElementById(id) { return elements[id] || null; },
+            dispatchEvent(event) { events.push(event.type); }
+        },
+        location: {href: 'http://localhost/vision/compare/', search: ''},
+        history: {replaceState() {}},
+        URL,
+        URLSearchParams,
+        CustomEvent: class CustomEvent {
+            constructor(type, options) {
+                this.type = type;
+                this.detail = options.detail;
+            }
+        },
+        fetch(url) {
+            assert.equal(url, '/vision/compare/data/');
+            return Promise.resolve({ok: true, json: () => Promise.resolve(payload())});
+        },
+        setTimeout,
+        clearTimeout
+    };
+    context.globalThis = context;
+
+    const source = fs.readFileSync(require.resolve('../compare-dashboard.js'), 'utf8');
+    vm.runInNewContext(source, context);
+    assert.equal(context.CompareDashboard, undefined);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.ok(context.CompareDashboard);
+    assert.equal(context.compare_dashboard_data.domain, 'vision');
+    assert.equal(elements['compare-dashboard-loading'].style.display, 'none');
+    assert.deepEqual(events, ['compare-dashboard:ready']);
+});

--- a/static/benchmarks/js/tests/compare-stability.test.js
+++ b/static/benchmarks/js/tests/compare-stability.test.js
@@ -1,7 +1,11 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
 
 const stability = require('../compare-stability.js');
+const correlation = require('../compare-correlation.js');
 
 test('builds historical snapshots and preserves the latest date', () => {
     assert.deepEqual(
@@ -30,6 +34,56 @@ test('uses the scatterplot paired-score rule for historical correlations', () =>
 
     assert.equal(result.r, 1);
     assert.equal(result.n, 3);
+});
+
+test('builds stability snapshots incrementally between scheduled tasks', async () => {
+    const payload = {
+        domain: 'vision',
+        datetime_range: {min: '2025-01-01', max: '2025-02-28'},
+        benchmarks: [
+            {id: 'average_vision_v0', type_id: 'average_vision', parent_id: null, is_leaf: false, is_engineering: false, versions: [{version: 0}]},
+            {id: 'left_v0', type_id: 'left', parent_id: 'average_vision_v0', is_leaf: true, is_engineering: false, versions: [{version: 0}]},
+            {id: 'right_v0', type_id: 'right', parent_id: 'average_vision_v0', is_leaf: true, is_engineering: false, versions: [{version: 0}]}
+        ],
+        models: [
+            {id: 1, name: 'one', submission_timestamp: null, scores: {left: [{version: 0, value: 1}], right: [{version: 0, value: 2}]}},
+            {id: 2, name: 'two', submission_timestamp: null, scores: {left: [{version: 0, value: 2}], right: [{version: 0, value: 4}]}}
+        ]
+    };
+    const options = {
+        firstBenchmarkId: 'left_v0',
+        secondBenchmarkId: 'right_v0',
+        dates: ['2025-01-31', '2025-02-28']
+    };
+    const tasks = [];
+    const resultPromise = stability.buildStabilitySeriesIncrementally(
+        payload,
+        options,
+        callback => tasks.push(callback)
+    );
+
+    assert.equal(tasks.length, 1);
+    while (tasks.length) tasks.shift()();
+    const result = await resultPromise;
+
+    assert.deepEqual(result, stability.buildStabilitySeries(payload, options));
+    assert.equal(result.length, 2);
+});
+
+test('resolves the correlation helper after stability initializes', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../compare-stability.js'), 'utf8');
+    const browserContext = {CompareDashboardCore: {}};
+    vm.createContext(browserContext);
+    vm.runInContext(source, browserContext);
+
+    browserContext.CompareCorrelationCore = correlation;
+    const result = browserContext.CompareStabilityCore.pairedCorrelation([
+        {'left-score': 1, 'left-is_complete': 1, 'right-score': 2, 'right-is_complete': 1},
+        {'left-score': 2, 'left-is_complete': 1, 'right-score': 4, 'right-is_complete': 1}
+    ], 'left', 'right');
+
+    assert.equal(result.r, 1);
+    assert.equal(result.n, 2);
 });
 
 test('exports readable stability data without benchmark ids', () => {
@@ -73,4 +127,8 @@ test('makes the compact timeline static and the expanded timeline interactive', 
     assert.equal(expanded.config.displayModeBar, true);
     assert.equal(expanded.layout.hovermode, 'x unified');
     assert.equal(expanded.layout.xaxis.title, 'Wayback date');
+    assert.equal(expanded.layout.yaxis.title.text, 'Pearson r');
+    assert.equal(expanded.layout.yaxis2.title.text, 'Paired models');
+    assert.equal(expanded.layout.yaxis.automargin, true);
+    assert.equal(expanded.layout.yaxis2.automargin, true);
 });


### PR DESCRIPTION
## Summary

- Add a compact quick-selection dropdown above the benchmark matrix tree.
- Discover RDM, Ridge, and fMRI benchmarks from live benchmark names.
- Group NSD and THINGS stimulus-family benchmarks without hardcoding versioned identifiers.
- Preserve Wayback availability, tree aggregation semantics, and the existing matrix action layout.
- Replace the benchmark scatter with an interactive Plotly view that supports zooming, modebar controls, branded exports, and SVG downloads.
- Keep matrix and scatter branding visible in both collapsed and expanded layouts.
- Preserve plot dimensions across repeated expand and collapse transitions.
- Label both axes in the expanded correlation stability view and build its historical snapshots incrementally to keep the page responsive.
- Render the compare-page shell before asynchronously fetching the score payload, with loading and error states for both vision and language.
- Initialize dependent compare analyses through a shared dashboard-ready event without database changes.

## Performance

- Reduce the initial vision compare HTML response from approximately 11.7 MB to 199 KB by moving the score payload to a JSON endpoint.
- Yield between stability snapshots instead of blocking initial plot rendering with the full historical calculation.

