### PR TITLE
fix(compare): stabilize responsive scatter sizing

### DIFF
--- a/static/benchmarks/js/compare-analysis-expand.js
+++ b/static/benchmarks/js/compare-analysis-expand.js
@@ -44,19 +44,28 @@
         return Number.isFinite(value) && value > 0 ? value : null;
     }
 
+    function rememberCollapsedPlotSize(plot, size) {
+        size = size || {};
+        plot.__compareCollapsedSize = {
+            height: finiteDimension(size.height) || 480,
+            width: finiteDimension(size.width),
+            autosize: size.autosize !== false
+        };
+        return plot.__compareCollapsedSize;
+    }
+
     function collapsedPlotSize(plot) {
         if (plot.__compareCollapsedSize) return plot.__compareCollapsedSize;
         var layout = plot.layout || {};
         var fullLayout = plot._fullLayout || {};
-        plot.__compareCollapsedSize = {
+        return rememberCollapsedPlotSize(plot, {
             height: finiteDimension(layout.height) ||
                 finiteDimension(fullLayout.height) ||
                 finiteDimension(plot.clientHeight) ||
                 480,
             width: finiteDimension(layout.width),
             autosize: layout.autosize !== false
-        };
-        return plot.__compareCollapsedSize;
+        });
     }
 
     function resizeAfterRelayout(plot, plotly, browserRoot, update) {
@@ -134,6 +143,7 @@
         expandIconClass: expandIconClass,
         expandedPlotHeight: expandedPlotHeight,
         initializeExpandButtons: initializeExpandButtons,
+        rememberCollapsedPlotSize: rememberCollapsedPlotSize,
         resizePlots: resizePlots,
         updateButton: updateButton
     };

--- a/static/benchmarks/js/compare-correlation.js
+++ b/static/benchmarks/js/compare-correlation.js
@@ -530,6 +530,10 @@
         return [minimum - padding, maximum + padding];
     }
 
+    function responsiveScatterHeight(width) {
+        return Math.max(480, Math.min(760, Math.round((Number(width) || 0) * 2 / 3)));
+    }
+
     function buildPlotlyBenchmarkScatter(points, options) {
         options = options || {};
         var xValues = points.map(function (point) { return point.x; });
@@ -1119,6 +1123,7 @@
         matrixToCsv: matrixToCsv,
         paddedScatterRange: paddedScatterRange,
         pearsonCorrelation: pearsonCorrelation,
+        responsiveScatterHeight: responsiveScatterHeight,
         selectAllBenchmarks: selectAllBenchmarks,
         setBenchmarkMode: setBenchmarkMode,
         validMatrixScore: validMatrixScore

--- a/static/benchmarks/js/compare.js
+++ b/static/benchmarks/js/compare.js
@@ -14,6 +14,32 @@ function initializeBenchmarkComparison() {
         xKey = null,
         yKey = null;
     const scatterElement = document.querySelector(container_selector);
+    const scatterPanel = document.getElementById('benchmark-scatter-panel');
+
+    function scatterIsExpanded() {
+        return !!(scatterPanel && scatterPanel.classList.contains('is-expanded-plot'));
+    }
+
+    function currentScatterHeight() {
+        const expandCore = window.CompareAnalysisExpandCore;
+        if (scatterIsExpanded() && expandCore) {
+            return expandCore.expandedPlotHeight(window.innerHeight);
+        }
+        return window.CompareCorrelationCore.responsiveScatterHeight(
+            $(container_selector).width()
+        );
+    }
+
+    function rememberCollapsedScatterSize(height) {
+        const expandCore = window.CompareAnalysisExpandCore;
+        if (!scatterIsExpanded() && expandCore && scatterElement) {
+            expandCore.rememberCollapsedPlotSize(scatterElement, {
+                height: height,
+                width: null,
+                autosize: true
+            });
+        }
+    }
 
     function currentComparisonData() {
         if (window.CompareDashboard) return window.CompareDashboard.getComparisonData();
@@ -140,10 +166,13 @@ function initializeBenchmarkComparison() {
                 statsText: statsText,
                 regression: {slope: slope, intercept: intercept},
                 logoSource: window.logo_url || '/static/benchmarks/img/logo.png',
-                height: Math.max(480, Math.min(760, Math.round($(container_selector).width() * 2 / 3)))
+                height: currentScatterHeight()
             }
         );
-        window.Plotly.react(scatterElement, plot.data, plot.layout, plot.config);
+        Promise.resolve(window.Plotly.react(scatterElement, plot.data, plot.layout, plot.config))
+            .then(function () {
+                rememberCollapsedScatterSize(plot.layout.height);
+            });
     }
 
     function syncComparisonBenchmarks() {
@@ -198,12 +227,24 @@ function initializeBenchmarkComparison() {
     updatePlot();
 
     let _cmpResizeTimer = null;
+    let _cmpResizeGeneration = 0;
     $(window).on('resize', function () {
         clearTimeout(_cmpResizeTimer);
         _cmpResizeTimer = setTimeout(function () {
-            if (window.Plotly && window.Plotly.Plots && scatterElement) {
-                window.Plotly.Plots.resize(scatterElement);
-            }
+            if (!window.Plotly || !scatterElement || !scatterElement.layout) return;
+            const generation = ++_cmpResizeGeneration;
+            const height = currentScatterHeight();
+            Promise.resolve(window.Plotly.relayout(scatterElement, {
+                height: height,
+                width: null,
+                autosize: true
+            })).then(function () {
+                if (generation !== _cmpResizeGeneration) return;
+                rememberCollapsedScatterSize(height);
+                if (window.Plotly.Plots && window.Plotly.Plots.resize) {
+                    window.Plotly.Plots.resize(scatterElement);
+                }
+            });
         }, 200);
     });
 

--- a/static/benchmarks/js/tests/compare-analysis-expand.test.js
+++ b/static/benchmarks/js/tests/compare-analysis-expand.test.js
@@ -45,13 +45,14 @@ test('preserves the original collapsed size across repeated toggles', () => {
 
     expand.resizePlots(panel, true, browserRoot);
     expand.resizePlots(panel, false, browserRoot);
+    expand.rememberCollapsedPlotSize(plot, {height: 540, width: null, autosize: true});
     expand.resizePlots(panel, true, browserRoot);
     expand.resizePlots(panel, false, browserRoot);
 
     assert.equal(updates[0].height, 770);
     assert.equal(updates[1].height, 620);
     assert.equal(updates[2].height, 770);
-    assert.equal(updates[3].height, 620);
+    assert.equal(updates[3].height, 540);
     assert.equal(updates[1].autosize, true);
     assert.equal(updates[3].width, null);
 });

--- a/static/benchmarks/js/tests/compare-correlation.test.js
+++ b/static/benchmarks/js/tests/compare-correlation.test.js
@@ -285,6 +285,12 @@ test('pads constant score ranges so scatter axes remain visible', () => {
     assert.deepEqual(correlation.paddedScatterRange([1, 1]), [0.95, 1.05]);
 });
 
+test('keeps responsive scatter heights within the dashboard bounds', () => {
+    assert.equal(correlation.responsiveScatterHeight(600), 480);
+    assert.equal(correlation.responsiveScatterHeight(900), 600);
+    assert.equal(correlation.responsiveScatterHeight(1400), 760);
+});
+
 test('starts a positive-only Plotly color scale at the lowest correlation', () => {
     const matrix = {
         axes: benchmarks().slice(0, 2),


### PR DESCRIPTION
## Summary

- Recalculate the benchmark scatter height from its current container width after viewport changes.
- Use viewport-derived height while the scatter is expanded.
- Refresh the saved collapsed dimensions so resizing does not restore a stale plot size.
- Ignore stale asynchronous resize completions during rapid viewport changes.
- Preserve responsive sizing when benchmarks change in either collapsed or expanded mode.

## Testing

- `npm run test:compare-dashboard` (59 tests)
- Verified the rebuilt local JavaScript bundle contains the responsive resize path.
- Verified the local compare page and asynchronous data endpoint return HTTP 200.
