### PR TITLE
feat(home): redesign landing page as live dashboard

### DIFF
--- a/benchmarks/templates/benchmarks/landing_page.html
+++ b/benchmarks/templates/benchmarks/landing_page.html
@@ -1,159 +1,265 @@
 {% extends 'benchmarks/base.html' %}
 {% load static %}
-{% load compress %}
 
+{% block third_party_viz_libs %}{% endblock %}
+
+{% block page_head_scripts %}
+<script defer src="{% static 'benchmarks/js/landing-dashboard.js' %}"></script>
+{% endblock %}
 
 {% block main %}
-<nav class="navbar updated is-fixed-top is-transparent">
-    <div class= "container my_container nav-container">
+<nav class="navbar updated is-fixed-top is-transparent landing-nav" aria-label="Primary navigation">
+    <div class="container my_container nav-container">
         <div class="navbar-brand">
-            <a class="navbar-item" href="https://www.brain-score.org">
-                    <img class="navbar_element image" id="navbar-logo-colored" src="/static/benchmarks/img/colored_logo.png"/>
+            <a class="navbar-item" href="/" aria-label="Brain-Score home">
+                <img class="navbar_element image" id="navbar-logo-colored"
+                     src="{% static 'benchmarks/img/colored_logo.png' %}" alt="Brain-Score">
             </a>
-            <a role="button" class="navbar-burger" data-target="navMenu" aria-label="menu" aria-expanded="false">
+            <a role="button" class="navbar-burger" data-target="navMenu" aria-label="Open navigation" aria-expanded="false">
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
             </a>
         </div>
         <div id="navMenu" class="navbar-menu">
-                <div class="navbar-end">
-                    <div class="navbar-item">
-                        <button onclick="location.href='../profile'" type="button" class="button new_design" >Log In</button>
-                        <a class="social_icon navbar-item " href="https://www.github.com/brain-score">
-                            <img class="navbar_element image" id="github_icon" src="/static/benchmarks/img/github_icon.png" />
-                        </a>
-                        <a class="social_icon navbar-item" href="https://www.twitter.com/brain_score">
-                            <img class="navbar_element image" id="twitter_icon" src="/static/benchmarks/img/twitter_icon.png"/>
-                        </a>
-                    </div>
+            <div class="navbar-end landing-nav__links">
+                <a class="navbar-item" href="/vision/explore/">Explore</a>
+                <a class="navbar-item" href="/vision/leaderboard/">Leaderboard</a>
+                <a class="navbar-item" href="/vision/compare/">Compare</a>
+                <a class="navbar-item" href="/tutorials/">Tutorials</a>
+                <div class="navbar-item">
+                    <a class="button landing-button landing-button--compact" href="/profile/">Log in</a>
                 </div>
+            </div>
         </div>
     </div>
 </nav>
-{% include "benchmarks/components/news-bar.html" %}
-<div class=" container my_container landing{% if news_items %} landing--has-news{% endif %}">
-    <div class="columns">
-        <div class="left_side column is-half has-text-centered-mobile">
-            <img class="logo_green image is-inline-block"  src="{% static "/benchmarks/img/logo_name_full.png" %}" />
-            <h3 class="landing_heading is-size-5 is-size-4-widescreen ">Integrative Benchmarks | Models at Scale </h3>
-            <p class="text-default-small is-size-6  has-text-justified-mobile">
-                The Brain-Score platform aims to yield accurate, machine-executable computational models of
-                how the brain gives rise to the mind. We enable researchers to quickly get a sense of the alignment of their model(s) to
-                currently dozens of neural and behavioral measurements, and provide these
-                models to experimentalists to prototype new experiments and make sense of biological data. </p>
-            <div class="domain_buttons container">
-                <button onclick="location.href='../vision/leaderboard'" type="button" class="button new_design domain_button is-size-7 is-size-6-widescreen" >Vision</button>
-                <button onclick="location.href='../language/leaderboard'" type="button" class="button new_design domain_button is-size-7 is-size-6-widescreen" >Language</button>
-            </div>
-        </div>
-        <div class="column is-half">
-            <picture>
-                <source srcset="{% static 'benchmarks/img/head_art_1.avif' %}" type="image/avif">
-                <source srcset="{% static 'benchmarks/img/head_art_1.webp' %}" type="image/webp">
-                <img class="head_art image" src="{% static 'benchmarks/img/head_art_1.png' %}" alt="Brain-Score hero illustration" decoding="async" fetchpriority="high" />
-            </picture>
-        </div>
-    </div>
-</div>
-<div class="container my_container main_body">
-    <div class="about container">
-        <div class="columns">
-            <div class="column is-half">
-                <img class="collab_graphic image"  src="{% static "/benchmarks/img/collaboration.png" %}" />
-            </div>
-            <div class="column is-half">
-                <h1 class="heading_green">Democratizing the Search for Scientific Models of Natural Intelligence</h1>
-                <p class=text-default>We believe in synergy between computational modeling and experimental brain
-                    and cognitive science. Brain-Score improves the efficiency of communication between experimentalists
-                    and modelers by providing experimental data as accessible benchmarks, and providing computational
-                    models in a unified form to experimentalists. All code is open-source and many community members
-                    have chosen to make their data or model weights fully public.</p>
-            </div>
-        </div>
-    </div>
-     <div class="benefits container ">
-         <img class="b-w_logo image"  src="{% static "/benchmarks/img/b-w_logo.png" %}" />
-         <div class="columns is-tablet is-variable is-1-tablet">
-             <div class="column is-one-third">
-                 <div class="benefits_card container">
-                     <img class="benefit_icon image"  src="{% static "/benchmarks/img/collab_icon.png" %}" />
-                     <h3 class="benefits_heading is-size-3-mobile ">Collaborative</h3>
-                     <p class="benefits_info is-size-5-mobile">Join the active and growing Brain-Score community.</p>
-                     <button onclick="location.href='../community'" type="button" class="button new_design benefit_button is-size-7
-                     is-size-6-widescreen" >Get Involved</button>
 
-                 </div>
-             </div>
-             <div class="column is-one-third">
-                 <div class="benefits_card container">
-                     <img class="benefit_icon image"  src="{% static "/benchmarks/img/book_icon.png" %}" />
-                     <h3 class="benefits_heading is-size-3-mobile">Open Source</h3>
-                     <p class="benefits_info is-size-5-mobile">Download and experiment. Completely free.</p>
-                    <button onclick="location.href='https://www.github.com/brain-score'" type="button" class="button
-                     new_design benefit_button is-size-7 is-size-6-widescreen " >Github</button>
-                 </div>
-             </div>
-             <div class="column is-one-third">
-                 <div class="benefits_card container">
-                    <img class="benefit_icon image"  src="{% static "/benchmarks/img/access_icon.png" %}" />
-                    <h3 class="benefits_heading is-size-3-mobile">Accessible</h3>
-                    <p class="benefits_info is-size-5-mobile">Interact seamlessly with our curated leaderboard.</p>
-                    <button onclick="location.href='../profile'" type="button" class="button new_design benefit_button is-size-7 is-size-6-widescreen" >Submit</button>
-                 </div>
+<div class="landing-dashboard">
+    <header class="landing-dashboard__intro container my_container">
+        <div>
+            <p class="landing-eyebrow">A living benchmark for computational models of the brain</p>
+            <h1>See what the field is building now.</h1>
+        </div>
+        <p>
+            Brain-Score brings models and neural and behavioral measurements into one
+            transparent, continuously evolving platform.
+        </p>
+    </header>
+
+    <section class="landing-opening container my_container" aria-label="Latest Brain-Score activity">
+        <div class="landing-panel landing-activity">
+            <div class="landing-section-heading">
+                <div>
+                    <p class="landing-eyebrow">Live from the community</p>
+                    <h2>Latest updates</h2>
+                </div>
+                <a href="/blog/">Read the blog <span aria-hidden="true">&rarr;</span></a>
+            </div>
+
+            <div class="landing-update-grid">
+                {% for item in news_items|slice:":3" %}
+                <article class="landing-update-card">
+                    <div class="landing-update-card__meta">
+                        <span class="landing-tag landing-tag--{{ item.kind|lower }}">{{ item.kind }}</span>
+                        {% if item.date %}<time datetime="{{ item.date|date:'Y-m-d' }}">{{ item.date|date:"M j" }}</time>{% endif %}
+                    </div>
+                    {% if item.link %}
+                    <a href="{{ item.link }}">{{ item.text }}</a>
+                    {% else %}
+                    <span>{{ item.text }}</span>
+                    {% endif %}
+                </article>
+                {% empty %}
+                <p class="landing-empty">New platform updates will appear here.</p>
+                {% endfor %}
+            </div>
+
+            <div class="landing-submissions-heading">
+                <h3>New model submissions</h3>
+                <a href="/vision/leaderboard/">View all models</a>
+            </div>
+            <div class="landing-submission-list">
+                {% for model in recent_models %}
+                <a class="landing-submission" href="/model/vision/{{ model.id }}">
+                    <span class="landing-avatar" aria-hidden="true">{{ model.initials }}</span>
+                    <span class="landing-submission__body">
+                        <strong>{{ model.name }}</strong>
+                        <span>{{ model.submitter }}</span>
+                    </span>
+                    {% if model.timestamp %}<time datetime="{{ model.timestamp|date:'c' }}">{{ model.timestamp|date:"M j" }}</time>{% endif %}
+                </a>
+                {% empty %}
+                <p class="landing-empty">Recent public submissions will appear here.</p>
+                {% endfor %}
             </div>
         </div>
-    </div>
-    <div class="landing_leaderboard container">
-        <div class="columns has-text-centered-mobile">
-            <div class="column is-half">
-                <h1 class=heading_green>Leaderboard</h1>
-                <p class="text-default ">At the core of Brain-Score is a leaderboard showing the latest evaluations of
-                    all available models on all available benchmarks. Models are ranked according to their average
-                    score across all the benchmarks because we believe the best model of a domain should explain all
-                    neural and behavioral data. The leaderboard also provides finer-grain per-benchmark and per-model
-                    scores for a more detailed view into where current models most need to improve on and which
-                    benchmarks are the most challenging.
+
+        <aside class="landing-onboarding" aria-labelledby="landing-onboarding-title">
+            <span class="landing-onboarding__icon" aria-hidden="true"><i class="fa-solid fa-compass"></i></span>
+            <p class="landing-eyebrow">New here?</p>
+            <h2 id="landing-onboarding-title">Learn how Brain-Score works</h2>
+            <p>
+                Start with the scientific idea, then explore how benchmarks turn experimental
+                measurements into executable tests for models.
+            </p>
+            <ol class="landing-onboarding__steps">
+                <li><span>1</span>Choose a model or benchmark</li>
+                <li><span>2</span>Inspect its scores and metadata</li>
+                <li><span>3</span>Compare it with the field</li>
+            </ol>
+            <a class="button landing-button" href="/tutorials/">Start with Brain-Score</a>
+            <a class="landing-text-link" href="/faq/">What is a Brain-Score?</a>
+        </aside>
+    </section>
+
+    <section class="landing-explore container my_container" aria-labelledby="landing-explore-title">
+        <div class="landing-section-heading landing-section-heading--wide">
+            <div>
+                <p class="landing-eyebrow">Explore the field</p>
+                <h2 id="landing-explore-title">A map of benchmark performance</h2>
+                <p>
+                    Public vision models projected from their V1, V2, V4, IT, and behavioral scores.
+                    Nearby models have more similar benchmark profiles.
                 </p>
             </div>
-            <div class="column has-text-centered-mobile">
-                <div class="benefits_card container">
-                    <img class="benefit_icon image"  src="{% static "/benchmarks/img/upload_icon.png" %}" />
-                    <h3 class=benefits_heading>Ready to Submit?</h3>
-                    <p class="leaderboard_info">Below you will find links on how to prepare a model for submission and
-                        receive a Brain-Score! You will also find the same for submitting a benchmark, with detailed
-                        tutorials available for both modelers and experimentalists. </p>
-                    <button onclick="location.href='../tutorials'"
-                            type="button" class="button new_design tutorial_button" >Tutorials</button>
-                    <button onclick="location.href='../profile/'" type="button" class="button new_design hollow_button" >Submit</button>
-                 </div>
+            <a class="button landing-button landing-button--outline" href="/vision/compare/">Open Compare</a>
+        </div>
+
+        <div class="landing-explore__grid">
+            <article class="landing-panel landing-space-card">
+                <div class="landing-card-heading">
+                    <div>
+                        <span class="landing-tag landing-tag--benchmark">Vision PCA</span>
+                        <h3>The benchmark space</h3>
+                    </div>
+                    <span class="landing-card-heading__hint"><i class="fa-regular fa-hand-pointer" aria-hidden="true"></i> Hover to inspect</span>
+                </div>
+                <div id="landing-benchmark-space" class="landing-space" role="group"
+                     aria-label="Principal component map of public vision models">
+                    <div class="landing-space__empty">Loading benchmark space&hellip;</div>
+                </div>
+                <p class="landing-method">
+                    A lightweight two-component preview of the highest-ranked public models with
+                    complete scores across the five displayed branches.
+                </p>
+            </article>
+
+            <aside class="landing-panel landing-leaderboard-preview" aria-labelledby="landing-leaderboard-title">
+                <div class="landing-card-heading">
+                    <div>
+                        <span class="landing-tag landing-tag--platform">Live ranking</span>
+                        <h3 id="landing-leaderboard-title">Leaderboard preview</h3>
+                    </div>
+                </div>
+                <div class="landing-leaderboard-list">
+                    {% for model in leaderboard_models %}
+                    <a class="landing-leaderboard-row" href="/model/vision/{{ model.id }}">
+                        <span class="landing-leaderboard-row__rank">{{ model.rank }}</span>
+                        <span class="landing-leaderboard-row__model">
+                            <strong>{{ model.name }}</strong>
+                            <span>{{ model.submitter }}</span>
+                        </span>
+                        <span class="landing-leaderboard-row__score">
+                            {% if model.score is not None %}{{ model.score|floatformat:3 }}{% else %}&mdash;{% endif %}
+                        </span>
+                    </a>
+                    {% empty %}
+                    <p class="landing-empty">Leaderboard data is temporarily unavailable.</p>
+                    {% endfor %}
+                </div>
+                <div class="landing-leaderboard-preview__footer">
+                    {% if public_model_count %}
+                    <span>{{ public_model_count }} public models</span>
+                    {% endif %}
+                    {% if benchmark_count %}
+                    <span>{{ benchmark_count }} active benchmark entries</span>
+                    {% endif %}
+                </div>
+                <a class="button landing-button landing-button--full" href="/vision/leaderboard/">Explore the full leaderboard</a>
+            </aside>
+        </div>
+    </section>
+
+    <section class="landing-compare container my_container" aria-labelledby="landing-compare-title">
+        <div class="landing-section-heading landing-section-heading--wide">
+            <div>
+                <p class="landing-eyebrow">Look beyond a single score</p>
+                <h2 id="landing-compare-title">Compare the evidence</h2>
+                <p>Move from ranking to analysis with the new comparison dashboards.</p>
             </div>
         </div>
-    </div>
-    <div class="container my_container main_footer">
-        <div class="columns has-text-centered-mobile">
-            <div class="column has-text-centered ">
-                <img class="white_logo image is-inline-block"  src="{% static "/benchmarks/img/White_logo_full.png" %}" />
+        <div class="landing-compare__grid">
+            <a class="landing-compare-card" href="/vision/compare/">
+                <div class="landing-compare-card__copy">
+                    <span class="landing-tag landing-tag--benchmark">Benchmarks</span>
+                    <h3>Which measurements move together?</h3>
+                    <p>Build a benchmark cohort, inspect correlations, and follow their stability through time.</p>
+                    <span class="landing-card-link">Compare benchmarks <span aria-hidden="true">&rarr;</span></span>
+                </div>
+                <div class="landing-mini-matrix" aria-hidden="true">
+                    <span></span><span></span><span></span><span></span>
+                    <span></span><span></span><span></span><span></span>
+                    <span></span><span></span><span></span><span></span>
+                    <span></span><span></span><span></span><span></span>
+                </div>
+            </a>
+            <a class="landing-compare-card landing-compare-card--models" href="/vision/compare/?tab=models">
+                <div class="landing-compare-card__copy">
+                    <span class="landing-tag landing-tag--model">Models</span>
+                    <h3>Where do two models meaningfully differ?</h3>
+                    <p>Compare scores, benchmark branches, ranks, and historical trajectories side by side.</p>
+                    <span class="landing-card-link">Compare models <span aria-hidden="true">&rarr;</span></span>
+                </div>
+                <div class="landing-mini-differences" aria-hidden="true">
+                    <span><i></i><b></b></span>
+                    <span><i></i><b></b></span>
+                    <span><i></i><b></b></span>
+                    <span><i></i><b></b></span>
+                    <span><i></i><b></b></span>
+                </div>
+            </a>
+        </div>
+    </section>
+
+    <section class="landing-participate container my_container" aria-labelledby="landing-participate-title">
+        <div class="landing-participate__code">
+            <div class="landing-code-heading">
+                <span><i class="fa-solid fa-terminal" aria-hidden="true"></i> Run locally</span>
+                <span>Python 3.11</span>
             </div>
-            <div class="footer_middle column has-text-centered">
-                <div class="column">
-                    <button onclick="location.href='../community'" type="button" class="button  simple_button" >Support</button>
-                    <button onclick="location.href='../faq'" type="button" class="button simple_button" >FAQ</button>
-                </div>
-                <div class="column">
-                    <button onclick="location.href='../tutorials'" type="button" class="button simple_button" >Tutorials</button>
-                    <button onclick="location.href='{% static "benchmarks/terms_and_conditions.pdf" %}'" type="button" class="button simple_button" >Terms of Use</button>
-                </div>
-                 <div class="column">
-                    <button onclick="location.href='https://github.com/brain-score/brain-score#references'" type="button" class="button simple_button" >Citations</button>
-                    <button onclick="location.href='https://github.com/brain-score/brain-score#license'" type="button" class="button simple_button" >License</button>
-                </div>
-                <div class="column">
-                    <button onclick="location.href='../sponsors'" type="button" class="button simple_button" >Sponsors</button>
-                    <button onclick="location.href='https://github.com/orgs/brain-score/people'" type="button" class="button simple_button" >Contributors</button>
-                </div>
+            <pre><code><span>git clone</span> https://github.com/brain-score/vision.git
+<span>pip install</span> ./vision
+<span>python brainscore_vision score</span> \
+  --model_identifier=pixels \
+  --benchmark_identifier=MajajHong2015public.IT-pls</code></pre>
+        </div>
+        <div class="landing-participate__copy">
+            <p class="landing-eyebrow">Build with us</p>
+            <h2 id="landing-participate-title">Use it locally. Add to it openly.</h2>
+            <p>
+                Run models against benchmarks on your own machine, contribute a new model or
+                measurement, and help define what the next generation of brain models should explain.
+            </p>
+            <div class="landing-participate__actions">
+                <a class="button landing-button" href="/tutorials/models/quickstart">Local quickstart</a>
+                <a class="button landing-button landing-button--outline" href="/community">Get involved</a>
+                <a class="landing-text-link" href="https://github.com/brain-score">View on GitHub</a>
             </div>
         </div>
-    </div>
+    </section>
+
+    <footer class="landing-footer container my_container">
+        <img src="{% static 'benchmarks/img/White_logo_full.png' %}" alt="Brain-Score">
+        <p>Community-built benchmarks for models of natural intelligence.</p>
+        <nav aria-label="Footer navigation">
+            <a href="/sponsors/">Sponsors</a>
+            <a href="/faq/">FAQ</a>
+            <a href="/tutorials/">Tutorials</a>
+            <a href="https://github.com/brain-score/brain-score#references">Citations</a>
+        </nav>
+    </footer>
 </div>
+
+{{ benchmark_space|json_script:"landing-benchmark-space-data" }}
 {% endblock %}

--- a/benchmarks/templates/benchmarks/landing_page.html
+++ b/benchmarks/templates/benchmarks/landing_page.html
@@ -119,8 +119,8 @@
                 <p class="landing-eyebrow">Explore the field</p>
                 <h2 id="landing-explore-title">A map of benchmark performance</h2>
                 <p>
-                    Public vision models projected from their V1, V2, V4, IT, and behavioral scores.
-                    Nearby models have more similar benchmark profiles.
+                    Public vision models projected from their V1, V2, V4,
+                    IT, and behavioral scores. Nearby models have more similar benchmark profiles.
                 </p>
             </div>
             <a class="button landing-button landing-button--outline" href="/vision/compare/">Open Compare</a>
@@ -131,17 +131,27 @@
                 <div class="landing-card-heading">
                     <div>
                         <span class="landing-tag landing-tag--benchmark">Vision PCA</span>
-                        <h3>The benchmark space</h3>
+                        <h3 id="landing-space-title">The 2D benchmark space</h3>
                     </div>
-                    <span class="landing-card-heading__hint"><i class="fa-regular fa-hand-pointer" aria-hidden="true"></i> Hover to inspect</span>
+                    <div class="landing-card-heading__tools">
+                        <div class="landing-space-toggle" aria-label="Benchmark-space dimensions">
+                            <button type="button" data-space-mode="2d" aria-pressed="true">2D</button>
+                            <button type="button" data-space-mode="3d" aria-pressed="false">3D</button>
+                        </div>
+                        <span id="landing-space-hint" class="landing-card-heading__hint">PC1 &times; PC2</span>
+                        <button id="landing-space-reset" class="landing-icon-button" type="button"
+                                aria-label="Reset 3D view" title="Reset 3D view" hidden>
+                            <i class="fa-solid fa-rotate-left" aria-hidden="true"></i>
+                        </button>
+                    </div>
                 </div>
-                <div id="landing-benchmark-space" class="landing-space" role="group"
-                     aria-label="Principal component map of public vision models">
+                <div id="landing-benchmark-space" class="landing-space" role="group" data-space-mode="2d"
+                     aria-label="Two-dimensional principal component map of public vision models">
                     <div class="landing-space__empty">Loading benchmark space&hellip;</div>
                 </div>
-                <p class="landing-method">
-                    A lightweight two-component preview of the highest-ranked public models with
-                    complete scores across the five displayed branches.
+                <p id="landing-space-method" class="landing-method">
+                    A two-component preview of the highest-ranked public models with complete scores
+                    across the five displayed branches. Hover or focus a point for model details.
                 </p>
             </article>
 

--- a/benchmarks/templates/benchmarks/landing_page.html
+++ b/benchmarks/templates/benchmarks/landing_page.html
@@ -37,18 +37,31 @@
 
 <div class="landing-dashboard">
     <header class="landing-dashboard__intro container my_container">
-        <div>
-            <p class="landing-eyebrow">A living benchmark for computational models of the brain</p>
-            <h1>See what the field is building now.</h1>
+        <div class="landing-hero__copy">
+            <img class="landing-hero__wordmark" src="{% static 'benchmarks/img/logo_name_full.png' %}"
+                 alt="Brain-Score">
+            <p class="landing-eyebrow">Integrative benchmarks <span aria-hidden="true">|</span> Models at scale</p>
+            <p class="landing-hero__summary">
+                Brain-Score brings models and neural and behavioral measurements into one
+                transparent, continuously evolving platform.
+            </p>
+            <div class="landing-bridge" aria-label="Brain-Score bridges computational models and brain measurements">
+                <span class="landing-bridge__endpoint landing-bridge__endpoint--models">Models</span>
+                <span class="landing-bridge__line" aria-hidden="true">
+                    <img src="{% static 'benchmarks/img/colored_logo.png' %}" alt="">
+                </span>
+                <span class="landing-bridge__endpoint landing-bridge__endpoint--brain">Brain and behavior</span>
+            </div>
         </div>
-        <p>
-            Brain-Score brings models and neural and behavioral measurements into one
-            transparent, continuously evolving platform.
-        </p>
+        <picture class="landing-hero__art" aria-hidden="true">
+            <source srcset="{% static 'benchmarks/img/head_art_1.avif' %}" type="image/avif">
+            <source srcset="{% static 'benchmarks/img/head_art_1.webp' %}" type="image/webp">
+            <img src="{% static 'benchmarks/img/head_art_1.png' %}" alt="" decoding="async" fetchpriority="high">
+        </picture>
     </header>
 
     <section class="landing-opening container my_container" aria-label="Latest Brain-Score activity">
-        <div class="landing-panel landing-activity">
+        <div class="landing-panel landing-panel--bridge landing-activity">
             <div class="landing-section-heading">
                 <div>
                     <p class="landing-eyebrow">Live from the community</p>
@@ -96,6 +109,11 @@
         </div>
 
         <aside class="landing-onboarding" aria-labelledby="landing-onboarding-title">
+            <picture class="landing-onboarding__network" aria-hidden="true">
+                <source srcset="{% static 'benchmarks/img/CNN_abstract.avif' %}" type="image/avif">
+                <source srcset="{% static 'benchmarks/img/CNN_abstract.webp' %}" type="image/webp">
+                <img src="{% static 'benchmarks/img/CNN_abstract.png' %}" alt="" decoding="async">
+            </picture>
             <span class="landing-onboarding__icon" aria-hidden="true"><i class="fa-solid fa-compass"></i></span>
             <p class="landing-eyebrow">New here?</p>
             <h2 id="landing-onboarding-title">Learn how Brain-Score works</h2>
@@ -127,7 +145,7 @@
         </div>
 
         <div class="landing-explore__grid">
-            <article class="landing-panel landing-space-card">
+            <article class="landing-panel landing-panel--bridge landing-space-card">
                 <div class="landing-card-heading">
                     <div>
                         <span class="landing-tag landing-tag--benchmark">Vision PCA</span>
@@ -155,7 +173,7 @@
                 </p>
             </article>
 
-            <aside class="landing-panel landing-leaderboard-preview" aria-labelledby="landing-leaderboard-title">
+            <aside class="landing-panel landing-panel--models landing-leaderboard-preview" aria-labelledby="landing-leaderboard-title">
                 <div class="landing-card-heading">
                     <div>
                         <span class="landing-tag landing-tag--platform">Live ranking</span>

--- a/benchmarks/tests/test_landing.py
+++ b/benchmarks/tests/test_landing.py
@@ -24,7 +24,7 @@ def _model(model_id, values, rank=None):
 
 
 class BenchmarkSpaceTests(SimpleTestCase):
-    def test_projects_complete_models_onto_two_components(self):
+    def test_projects_complete_models_onto_three_components(self):
         models = [
             _model(1, [0.20, 0.24, 0.30, 0.35, 0.40]),
             _model(2, [0.23, 0.28, 0.31, 0.39, 0.42]),
@@ -40,8 +40,11 @@ class BenchmarkSpaceTests(SimpleTestCase):
         self.assertEqual(projection["benchmarks"], ["V1", "V2", "V4", "IT", "Behavior"])
         self.assertTrue(all(math.isfinite(point["x"]) for point in projection["points"]))
         self.assertTrue(all(math.isfinite(point["y"]) for point in projection["points"]))
+        self.assertTrue(all(math.isfinite(point["z"]) for point in projection["points"]))
+        self.assertEqual(len(projection["variance"]), 3)
         self.assertGreater(projection["variance"][0], 0)
         self.assertGreaterEqual(projection["variance"][0], projection["variance"][1])
+        self.assertGreaterEqual(projection["variance"][1], projection["variance"][2])
 
     def test_excludes_models_without_complete_nonzero_branch_scores(self):
         complete = _model(1, [0.20, 0.24, 0.30, 0.35, 0.40])
@@ -62,7 +65,7 @@ class LandingPageTests(SimpleTestCase):
             "news_items": [],
             "recent_models": [],
             "leaderboard_models": [],
-            "benchmark_space": {"points": [], "variance": [0, 0], "benchmarks": []},
+            "benchmark_space": {"points": [], "variance": [0, 0, 0], "benchmarks": []},
             "public_model_count": None,
             "benchmark_count": None,
         }
@@ -71,7 +74,8 @@ class LandingPageTests(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Latest updates")
-        self.assertContains(response, "The benchmark space")
+        self.assertContains(response, "The 2D benchmark space")
+        self.assertContains(response, 'data-space-mode="2d"')
         self.assertContains(response, "Compare benchmarks")
         self.assertContains(response, "Compare models")
         self.assertContains(response, "Run locally")

--- a/benchmarks/tests/test_landing.py
+++ b/benchmarks/tests/test_landing.py
@@ -1,0 +1,77 @@
+import math
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from benchmarks.views.landing import PCA_BENCHMARKS, build_benchmark_space
+
+
+def _model(model_id, values, rank=None):
+    scores = [
+        {"benchmark_type_id": identifier, "score_ceiled": value}
+        for (identifier, _), value in zip(PCA_BENCHMARKS, values)
+    ]
+    scores.append({"benchmark_type_id": "average_vision", "score_ceiled": sum(values) / len(values)})
+    return SimpleNamespace(
+        model_id=model_id,
+        name=f"model-{model_id}",
+        rank=rank or model_id,
+        scores=scores,
+        submitter={"display_name": "Test Researcher"},
+        timestamp=None,
+    )
+
+
+class BenchmarkSpaceTests(SimpleTestCase):
+    def test_projects_complete_models_onto_two_components(self):
+        models = [
+            _model(1, [0.20, 0.24, 0.30, 0.35, 0.40]),
+            _model(2, [0.23, 0.28, 0.31, 0.39, 0.42]),
+            _model(3, [0.31, 0.25, 0.38, 0.44, 0.36]),
+            _model(4, [0.37, 0.34, 0.45, 0.48, 0.50]),
+            _model(5, [0.42, 0.39, 0.40, 0.52, 0.47]),
+            _model(6, [0.48, 0.45, 0.54, 0.58, 0.56]),
+        ]
+
+        projection = build_benchmark_space(models)
+
+        self.assertEqual(len(projection["points"]), len(models))
+        self.assertEqual(projection["benchmarks"], ["V1", "V2", "V4", "IT", "Behavior"])
+        self.assertTrue(all(math.isfinite(point["x"]) for point in projection["points"]))
+        self.assertTrue(all(math.isfinite(point["y"]) for point in projection["points"]))
+        self.assertGreater(projection["variance"][0], 0)
+        self.assertGreaterEqual(projection["variance"][0], projection["variance"][1])
+
+    def test_excludes_models_without_complete_nonzero_branch_scores(self):
+        complete = _model(1, [0.20, 0.24, 0.30, 0.35, 0.40])
+        second = _model(2, [0.25, 0.29, 0.36, 0.41, 0.46])
+        third = _model(3, [0.32, 0.37, 0.42, 0.48, 0.52])
+        incomplete = _model(4, [0.35, 0.39, 0, 0.50, 0.55])
+
+        projection = build_benchmark_space([complete, second, third, incomplete])
+
+        self.assertEqual([point["id"] for point in projection["points"]], [1, 2, 3])
+
+
+class LandingPageTests(SimpleTestCase):
+    @patch("benchmarks.views.landing.landing_context")
+    def test_homepage_exposes_dashboard_entry_points(self, context):
+        context.return_value = {
+            "comparison_data": "[]",
+            "news_items": [],
+            "recent_models": [],
+            "leaderboard_models": [],
+            "benchmark_space": {"points": [], "variance": [0, 0], "benchmarks": []},
+            "public_model_count": None,
+            "benchmark_count": None,
+        }
+
+        response = self.client.get("/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Latest updates")
+        self.assertContains(response, "The benchmark space")
+        self.assertContains(response, "Compare benchmarks")
+        self.assertContains(response, "Compare models")
+        self.assertContains(response, "Run locally")

--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -2,7 +2,7 @@ from functools import partial
 from django.conf import settings
 from django.urls import path
 from django.views.generic import RedirectView
-from .views import user, model, competition2022, competition2024, compare, community, \
+from .views import user, model, competition2022, competition2024, compare, community, landing, \
     release2_0, brain_model, content_utils, benchmark, explore, leaderboard, report_issue, blog, tutorials
 from .utils import show_token, refresh_cache, refresh_score_trends
 
@@ -12,8 +12,8 @@ supported_domains = ["vision", "language"]
 
 non_domain_urls = [
     # landing
-    path('', user.LandingPage.as_view(), name='landing_page'),
-    path('/', user.LandingPage.as_view(), name='landing_page'),
+    path('', landing.LandingPage.as_view(), name='landing_page'),
+    path('/', landing.LandingPage.as_view(), name='landing_page'),
 
     # global pages - default to vision domain
     path('explore/', RedirectView.as_view(url='/vision/explore/', permanent=False), name='default-explore'),

--- a/benchmarks/views/landing.py
+++ b/benchmarks/views/landing.py
@@ -1,0 +1,243 @@
+import logging
+import math
+
+from django.core.cache import cache
+from django.db import DatabaseError
+from django.shortcuts import render
+from django.views import View
+
+from benchmarks.models import FinalBenchmarkContext, FinalModelContext
+from benchmarks.utils import load_news
+
+
+_logger = logging.getLogger(__name__)
+
+PCA_BENCHMARKS = (
+    ("V1", "V1"),
+    ("V2", "V2"),
+    ("V4", "V4"),
+    ("IT", "IT"),
+    ("behavior_vision", "Behavior"),
+)
+
+
+def _finite_score(value):
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(score) or score == 0:
+        return None
+    return score
+
+
+def _score_lookup(model):
+    return {
+        score.get("benchmark_type_id"): _finite_score(score.get("score_ceiled"))
+        for score in (model.scores or [])
+    }
+
+
+def _normalize(vector):
+    length = math.sqrt(sum(value * value for value in vector))
+    if length <= 1e-12:
+        return None
+    return [value / length for value in vector]
+
+
+def _principal_vector(covariance, orthogonal_to=()):
+    dimension = len(covariance)
+    vector = _normalize([1 / (index + 1) for index in range(dimension)])
+    if vector is None:
+        return None, 0
+
+    for _ in range(100):
+        candidate = [
+            sum(covariance[row][column] * vector[column] for column in range(dimension))
+            for row in range(dimension)
+        ]
+        for basis in orthogonal_to:
+            projection = sum(candidate[index] * basis[index] for index in range(dimension))
+            candidate = [
+                candidate[index] - projection * basis[index]
+                for index in range(dimension)
+            ]
+        candidate = _normalize(candidate)
+        if candidate is None:
+            return None, 0
+        if sum(abs(candidate[index] - vector[index]) for index in range(dimension)) < 1e-10:
+            vector = candidate
+            break
+        vector = candidate
+
+    transformed = [
+        sum(covariance[row][column] * vector[column] for column in range(dimension))
+        for row in range(dimension)
+    ]
+    eigenvalue = max(0, sum(vector[index] * transformed[index] for index in range(dimension)))
+    return vector, eigenvalue
+
+
+def _initials(display_name):
+    if not display_name or display_name.lower() == "anonymous user":
+        return "BS"
+    words = [word for word in display_name.replace("_", " ").split() if word]
+    if len(words) > 1:
+        return (words[0][0] + words[-1][0]).upper()
+    return words[0][:2].upper()
+
+
+def _submitter_name(model):
+    submitter = model.submitter if isinstance(model.submitter, dict) else {}
+    display_name = submitter.get("display_name")
+    if not display_name or display_name.lower() == "anonymous user":
+        return "Brain-Score community"
+    return display_name
+
+
+def _model_summary(model):
+    scores = _score_lookup(model)
+    return {
+        "id": model.model_id,
+        "name": model.name,
+        "rank": model.rank,
+        "score": scores.get("average_vision"),
+        "timestamp": model.timestamp,
+        "submitter": _submitter_name(model),
+        "initials": _initials(_submitter_name(model)),
+    }
+
+
+def build_benchmark_space(models):
+    """Project complete high-level vision scores onto two principal components."""
+    identifiers = [identifier for identifier, _ in PCA_BENCHMARKS]
+    rows = []
+    for model in models:
+        scores = _score_lookup(model)
+        values = [scores.get(identifier) for identifier in identifiers]
+        if any(value is None for value in values):
+            continue
+        rows.append((model, values))
+
+    if len(rows) < 3:
+        return {"points": [], "variance": [0, 0], "benchmarks": []}
+
+    columns = list(zip(*(values for _, values in rows)))
+    means = [sum(column) / len(column) for column in columns]
+    deviations = [
+        math.sqrt(sum((value - means[index]) ** 2 for value in column) / len(column))
+        for index, column in enumerate(columns)
+    ]
+    standardized = [
+        [
+            (value - means[index]) / deviations[index] if deviations[index] > 1e-12 else 0
+            for index, value in enumerate(values)
+        ]
+        for _, values in rows
+    ]
+
+    dimension = len(identifiers)
+    covariance = [
+        [
+            sum(row[left] * row[right] for row in standardized) / (len(standardized) - 1)
+            for right in range(dimension)
+        ]
+        for left in range(dimension)
+    ]
+    first, first_value = _principal_vector(covariance)
+    second, second_value = _principal_vector(covariance, (first,)) if first else (None, 0)
+    if first is None or second is None:
+        return {"points": [], "variance": [0, 0], "benchmarks": []}
+
+    total_variance = sum(covariance[index][index] for index in range(dimension))
+    variance = [
+        round(100 * value / total_variance, 1) if total_variance > 0 else 0
+        for value in (first_value, second_value)
+    ]
+    points = []
+    for (model, _), row in zip(rows, standardized):
+        summary = _model_summary(model)
+        points.append({
+            "id": summary["id"],
+            "name": summary["name"],
+            "rank": summary["rank"],
+            "score": summary["score"],
+            "x": round(sum(row[index] * first[index] for index in range(dimension)), 5),
+            "y": round(sum(row[index] * second[index] for index in range(dimension)), 5),
+        })
+
+    return {
+        "points": points,
+        "variance": variance,
+        "benchmarks": [label for _, label in PCA_BENCHMARKS],
+    }
+
+
+def _update_kind(item):
+    text = item.get("text", "").lower()
+    if "benchmark" in text:
+        return "Benchmark"
+    if text.startswith("blog:"):
+        return "Story"
+    if "compare" in text or "leaderboard" in text or "released" in text:
+        return "Platform"
+    return "Update"
+
+
+def landing_context():
+    updates = []
+    for item in load_news()[:4]:
+        updates.append({**item, "kind": _update_kind(item)})
+
+    context = {
+        "comparison_data": "[]",
+        "news_items": updates,
+        "recent_models": [],
+        "leaderboard_models": [],
+        "benchmark_space": {"points": [], "variance": [0, 0], "benchmarks": []},
+        "public_model_count": None,
+        "benchmark_count": None,
+    }
+    cached_data = None
+    try:
+        cached_data = cache.get("landing_dashboard_data_v1")
+    except Exception as exc:
+        _logger.warning("Could not read cached landing dashboard data: %s", exc)
+    if cached_data:
+        context.update(cached_data)
+        return context
+
+    try:
+        top_models = list(
+            FinalModelContext.objects.filter(domain="vision", public=True)
+            .order_by("rank")[:80]
+        )
+        recent_models = list(
+            FinalModelContext.objects.filter(
+                domain="vision", public=True, timestamp__isnull=False
+            ).order_by("-timestamp")[:4]
+        )
+        dashboard_data = {
+            "recent_models": [_model_summary(model) for model in recent_models],
+            "leaderboard_models": [_model_summary(model) for model in top_models[:5]],
+            "benchmark_space": build_benchmark_space(top_models),
+            "public_model_count": FinalModelContext.objects.filter(
+                domain="vision", public=True
+            ).count(),
+            "benchmark_count": FinalBenchmarkContext.objects.filter(
+                domain="vision", visible=True
+            ).count(),
+        }
+        context.update(dashboard_data)
+        try:
+            cache.set("landing_dashboard_data_v1", dashboard_data, 15 * 60)
+        except Exception as exc:
+            _logger.warning("Could not cache landing dashboard data: %s", exc)
+    except DatabaseError as exc:
+        _logger.warning("Could not build landing dashboard data: %s", exc)
+    return context
+
+
+class LandingPage(View):
+    def get(self, request):
+        return render(request, "benchmarks/landing_page.html", landing_context())

--- a/benchmarks/views/landing.py
+++ b/benchmarks/views/landing.py
@@ -78,6 +78,25 @@ def _principal_vector(covariance, orthogonal_to=()):
     return vector, eigenvalue
 
 
+def _orthogonal_vector(dimension, orthogonal_to):
+    """Return a deterministic unused axis when a component has zero variance."""
+    best = None
+    best_length = 0
+    for axis in range(dimension):
+        candidate = [1 if index == axis else 0 for index in range(dimension)]
+        for basis in orthogonal_to:
+            projection = sum(candidate[index] * basis[index] for index in range(dimension))
+            candidate = [
+                candidate[index] - projection * basis[index]
+                for index in range(dimension)
+            ]
+        length = math.sqrt(sum(value * value for value in candidate))
+        if length > best_length:
+            best = candidate
+            best_length = length
+    return _normalize(best) if best is not None else None
+
+
 def _initials(display_name):
     if not display_name or display_name.lower() == "anonymous user":
         return "BS"
@@ -109,7 +128,7 @@ def _model_summary(model):
 
 
 def build_benchmark_space(models):
-    """Project complete high-level vision scores onto two principal components."""
+    """Project complete high-level vision scores onto three principal components."""
     identifiers = [identifier for identifier, _ in PCA_BENCHMARKS]
     rows = []
     for model in models:
@@ -120,7 +139,7 @@ def build_benchmark_space(models):
         rows.append((model, values))
 
     if len(rows) < 3:
-        return {"points": [], "variance": [0, 0], "benchmarks": []}
+        return {"points": [], "variance": [0, 0, 0], "benchmarks": []}
 
     columns = list(zip(*(values for _, values in rows)))
     means = [sum(column) / len(column) for column in columns]
@@ -146,13 +165,21 @@ def build_benchmark_space(models):
     ]
     first, first_value = _principal_vector(covariance)
     second, second_value = _principal_vector(covariance, (first,)) if first else (None, 0)
-    if first is None or second is None:
-        return {"points": [], "variance": [0, 0], "benchmarks": []}
+    if second is None and first is not None:
+        second = _orthogonal_vector(dimension, (first,))
+    third, third_value = (
+        _principal_vector(covariance, (first, second))
+        if first and second else (None, 0)
+    )
+    if third is None and first is not None and second is not None:
+        third = _orthogonal_vector(dimension, (first, second))
+    if first is None or second is None or third is None:
+        return {"points": [], "variance": [0, 0, 0], "benchmarks": []}
 
     total_variance = sum(covariance[index][index] for index in range(dimension))
     variance = [
         round(100 * value / total_variance, 1) if total_variance > 0 else 0
-        for value in (first_value, second_value)
+        for value in (first_value, second_value, third_value)
     ]
     points = []
     for (model, _), row in zip(rows, standardized):
@@ -164,6 +191,7 @@ def build_benchmark_space(models):
             "score": summary["score"],
             "x": round(sum(row[index] * first[index] for index in range(dimension)), 5),
             "y": round(sum(row[index] * second[index] for index in range(dimension)), 5),
+            "z": round(sum(row[index] * third[index] for index in range(dimension)), 5),
         })
 
     return {
@@ -194,13 +222,13 @@ def landing_context():
         "news_items": updates,
         "recent_models": [],
         "leaderboard_models": [],
-        "benchmark_space": {"points": [], "variance": [0, 0], "benchmarks": []},
+        "benchmark_space": {"points": [], "variance": [0, 0, 0], "benchmarks": []},
         "public_model_count": None,
         "benchmark_count": None,
     }
     cached_data = None
     try:
-        cached_data = cache.get("landing_dashboard_data_v1")
+        cached_data = cache.get("landing_dashboard_data_v2")
     except Exception as exc:
         _logger.warning("Could not read cached landing dashboard data: %s", exc)
     if cached_data:
@@ -230,7 +258,7 @@ def landing_context():
         }
         context.update(dashboard_data)
         try:
-            cache.set("landing_dashboard_data_v1", dashboard_data, 15 * 60)
+            cache.set("landing_dashboard_data_v2", dashboard_data, 15 * 60)
         except Exception as exc:
             _logger.warning("Could not cache landing dashboard data: %s", exc)
     except DatabaseError as exc:

--- a/benchmarks/views/user.py
+++ b/benchmarks/views/user.py
@@ -22,7 +22,6 @@ from benchmarks.forms import SignupForm, LoginForm, UploadFileForm
 from benchmarks.models import Model, BenchmarkInstance, BenchmarkType, FileUploadTracker
 from benchmarks.ratelimit import DAILY_LIMIT, check_and_record_upload, get_recent_upload_count
 from benchmarks.tokens import account_activation_token
-from benchmarks.utils import load_news
 from benchmarks.views.leaderboard import get_ag_grid_context
 from benchmarks.views.index import get_context
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -166,12 +165,6 @@ class Login(View):
         else:
             context = {"Incorrect": True, 'form': LoginForm}
             return render(request, 'benchmarks/login.html', context)
-
-
-class LandingPage(View):
-    def get(self, request):
-        news = load_news()
-        return render(request, 'benchmarks/landing_page.html', {'news_items': news})
 
 
 class Logout(View):

--- a/static/benchmarks/css/landing_page.sass
+++ b/static/benchmarks/css/landing_page.sass
@@ -347,3 +347,801 @@ button.simple_button
     margin: auto
   .text-default-small
     font-size: 100%
+
+// Dashboard landing page
+.landing-nav
+  border-bottom: 1px solid rgba(0, 27, 54, 0.08)
+  box-shadow: 0 4px 20px rgba(0, 27, 54, 0.04)
+
+  .landing-nav__links
+    align-items: center
+
+    > .navbar-item
+      color: $brainscore_gray4
+      font-size: 0.9rem
+      font-weight: 600
+
+      &:hover
+        color: $brainscore_sky
+        background: transparent
+
+.landing-dashboard
+  min-height: 100vh
+  padding-top: 114px
+  color: $brainscore_gray4
+  font-family: "Open Sans", sans-serif
+  background: radial-gradient(circle at 8% 4%, rgba(69, 198, 118, 0.08), transparent 25rem), radial-gradient(circle at 92% 28%, rgba(71, 183, 222, 0.07), transparent 28rem), #fbfdfc
+
+  h1, h2, h3, p
+    margin: 0
+
+  h1
+    max-width: 720px
+    font-size: clamp(2.35rem, 4vw, 4.25rem)
+    line-height: 1.04
+    letter-spacing: -0.045em
+    font-weight: 700
+
+  h2
+    font-size: clamp(1.65rem, 2.3vw, 2.45rem)
+    line-height: 1.15
+    letter-spacing: -0.03em
+    font-weight: 700
+
+  h3
+    font-size: 1.15rem
+    line-height: 1.25
+    font-weight: 700
+
+  a
+    color: inherit
+
+.landing-dashboard__intro
+  display: flex
+  align-items: flex-end
+  justify-content: space-between
+  gap: 56px
+  padding: 54px 0 38px
+
+  > p
+    max-width: 470px
+    padding-bottom: 4px
+    color: #506272
+    font-size: 1.03rem
+    line-height: 1.7
+
+.landing-eyebrow
+  margin-bottom: 10px !important
+  color: #168b4b
+  font-size: 0.72rem
+  font-weight: 800
+  letter-spacing: 0.13em
+  text-transform: uppercase
+
+.landing-button.button
+  min-height: 42px
+  padding: 0.65rem 1.15rem
+  border: 1px solid #168b4b
+  border-radius: 8px
+  background: #168b4b
+  color: white
+  font-weight: 700
+  box-shadow: none
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease
+
+  &:hover, &:focus
+    border-color: #10783e
+    background: #10783e
+    color: white
+    transform: translateY(-1px)
+    box-shadow: 0 7px 18px rgba(22, 139, 75, 0.2)
+
+  &.landing-button--compact
+    min-height: 34px
+    padding: 0.4rem 1rem
+    font-size: 0.82rem
+
+  &.landing-button--outline
+    border-color: #b7c7c0
+    background: white
+    color: #116b3b
+
+    &:hover, &:focus
+      border-color: #168b4b
+      background: #f4fbf7
+      color: #116b3b
+
+  &.landing-button--full
+    width: 100%
+    margin-top: 20px
+
+.landing-text-link
+  display: inline-flex
+  align-items: center
+  color: #087da6 !important
+  font-size: 0.86rem
+  font-weight: 700
+  text-decoration: none
+
+  &:hover
+    text-decoration: underline
+
+.landing-panel
+  border: 1px solid #dce8e2
+  border-top: 4px solid $brainscore_green
+  border-radius: 12px
+  background: rgba(255, 255, 255, 0.94)
+  box-shadow: 0 12px 32px rgba(0, 27, 54, 0.07)
+
+.landing-opening
+  display: grid
+  grid-template-columns: minmax(0, 2.15fr) minmax(290px, 0.85fr)
+  gap: 22px
+  align-items: stretch
+
+.landing-activity
+  padding: 28px
+
+.landing-section-heading
+  display: flex
+  align-items: flex-start
+  justify-content: space-between
+  gap: 28px
+
+  > a
+    flex: 0 0 auto
+    margin-top: 8px
+    color: #087da6
+    font-size: 0.83rem
+    font-weight: 700
+
+  &.landing-section-heading--wide
+    align-items: flex-end
+    margin-bottom: 26px
+
+    > div > p:not(.landing-eyebrow)
+      max-width: 700px
+      margin-top: 10px
+      color: #5b6b78
+      line-height: 1.65
+
+.landing-update-grid
+  display: grid
+  grid-template-columns: repeat(3, minmax(0, 1fr))
+  gap: 12px
+  margin-top: 22px
+
+.landing-update-card
+  min-height: 132px
+  padding: 15px
+  border: 1px solid #e3ece7
+  border-radius: 9px
+  background: #f8fbf9
+
+  > a, > span
+    display: -webkit-box
+    overflow: hidden
+    color: $brainscore_gray4
+    font-size: 0.88rem
+    font-weight: 700
+    line-height: 1.45
+    text-decoration: none
+    -webkit-box-orient: vertical
+    -webkit-line-clamp: 3
+
+  > a:hover
+    color: #087da6
+
+.landing-update-card__meta
+  display: flex
+  align-items: center
+  justify-content: space-between
+  gap: 8px
+  margin-bottom: 14px
+
+  time
+    color: #7c8b96
+    font-size: 0.72rem
+    font-weight: 600
+
+.landing-tag
+  display: inline-flex
+  align-items: center
+  width: fit-content
+  padding: 3px 8px
+  border-radius: 999px
+  background: #e8f7ed
+  color: #137340
+  font-size: 0.65rem
+  font-weight: 800
+  letter-spacing: 0.05em
+  text-transform: uppercase
+
+  &.landing-tag--model
+    background: #e5f5fb
+    color: #087da6
+
+  &.landing-tag--story
+    background: #f1ebf7
+    color: #75508c
+
+  &.landing-tag--platform
+    background: #e8effc
+    color: #3f67a7
+
+.landing-submissions-heading
+  display: flex
+  align-items: baseline
+  justify-content: space-between
+  gap: 20px
+  margin: 28px 0 8px
+  padding-top: 20px
+  border-top: 1px solid #e4ece8
+
+  h3
+    font-size: 0.93rem
+
+  a
+    color: #087da6
+    font-size: 0.76rem
+    font-weight: 700
+
+.landing-submission-list
+  display: grid
+  grid-template-columns: repeat(2, minmax(0, 1fr))
+  gap: 6px 22px
+
+.landing-submission
+  display: grid
+  grid-template-columns: 34px minmax(0, 1fr) auto
+  gap: 10px
+  align-items: center
+  min-width: 0
+  padding: 8px 5px
+  border-radius: 7px
+  text-decoration: none
+
+  &:hover
+    background: #f2f8f5
+
+  > time
+    color: #83909a
+    font-size: 0.68rem
+
+.landing-avatar
+  display: inline-flex
+  align-items: center
+  justify-content: center
+  width: 34px
+  height: 34px
+  border: 1px solid #bce3ca
+  border-radius: 50%
+  background: linear-gradient(145deg, #e6f8ec, #e4f4fb)
+  color: #12683a
+  font-size: 0.67rem
+  font-weight: 800
+
+.landing-submission__body
+  min-width: 0
+
+  strong, span
+    display: block
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
+
+  strong
+    color: #203442
+    font-size: 0.77rem
+
+  span
+    margin-top: 2px
+    color: #71808b
+    font-size: 0.67rem
+
+.landing-onboarding
+  display: flex
+  flex-direction: column
+  min-height: 100%
+  padding: 30px
+  border-radius: 12px
+  background: linear-gradient(150deg, #082f2b 0%, #0a4a48 56%, #116879 100%)
+  color: white
+  box-shadow: 0 12px 32px rgba(0, 45, 51, 0.16)
+
+  .landing-eyebrow
+    color: #80e6a7
+
+  h2
+    max-width: 300px
+    font-size: 1.85rem
+
+  > p:not(.landing-eyebrow)
+    margin-top: 15px
+    color: #d4e9e6
+    font-size: 0.88rem
+    line-height: 1.65
+
+  .landing-button
+    margin-top: auto
+    border-color: #6ed89a
+    background: #6ed89a
+    color: #07372a
+
+  .landing-text-link
+    justify-content: center
+    margin-top: 15px
+    color: #b8eaf1 !important
+
+.landing-onboarding__icon
+  display: inline-flex
+  align-items: center
+  justify-content: center
+  width: 44px
+  height: 44px
+  margin-bottom: 30px
+  border: 1px solid rgba(255, 255, 255, 0.2)
+  border-radius: 10px
+  color: #80e6a7
+  background: rgba(255, 255, 255, 0.08)
+
+.landing-onboarding__steps
+  margin: 23px 0 28px
+  padding: 0
+  list-style: none
+
+  li
+    display: flex
+    align-items: center
+    gap: 10px
+    margin: 10px 0
+    color: #e3f0ee
+    font-size: 0.79rem
+
+    span
+      display: inline-flex
+      align-items: center
+      justify-content: center
+      width: 22px
+      height: 22px
+      border-radius: 50%
+      background: rgba(128, 230, 167, 0.13)
+      color: #8aebaf
+      font-size: 0.68rem
+      font-weight: 800
+
+.landing-explore, .landing-compare
+  padding-top: 92px
+
+.landing-explore__grid
+  display: grid
+  grid-template-columns: minmax(0, 1.75fr) minmax(300px, 0.75fr)
+  gap: 22px
+
+.landing-space-card, .landing-leaderboard-preview
+  padding: 24px
+
+.landing-card-heading
+  display: flex
+  align-items: flex-start
+  justify-content: space-between
+  gap: 20px
+  margin-bottom: 15px
+
+  h3
+    margin-top: 8px
+
+.landing-card-heading__hint
+  margin-top: 4px
+  color: #7a8993
+  font-size: 0.69rem
+
+.landing-space
+  position: relative
+  min-height: 390px
+  overflow: hidden
+  border: 1px solid #e1ebe6
+  border-radius: 8px
+  background: linear-gradient(rgba(240, 246, 243, 0.7) 1px, transparent 1px), linear-gradient(90deg, rgba(240, 246, 243, 0.7) 1px, transparent 1px), #fcfefd
+  background-size: 54px 54px
+
+  svg
+    display: block
+    width: 100%
+    min-height: 390px
+
+.landing-space__empty
+  display: flex
+  align-items: center
+  justify-content: center
+  min-height: 390px
+  color: #7f8c95
+  font-size: 0.84rem
+
+.landing-space__axis
+  stroke: #aebdb6
+  stroke-width: 1
+
+.landing-space__axis-label
+  fill: #687983
+  font-size: 11px
+  font-weight: 600
+
+.landing-space__point
+  cursor: pointer
+  opacity: 0
+  animation: landing-point-in 400ms ease forwards
+  transition: r 120ms ease, opacity 120ms ease, stroke-width 120ms ease
+
+  &:hover, &:focus
+    r: 7
+    opacity: 1
+    stroke-width: 2.5
+    outline: none
+
+@keyframes landing-point-in
+  from
+    opacity: 0
+  to
+    opacity: 0.76
+
+.landing-space__tooltip
+  position: absolute
+  z-index: 2
+  max-width: 245px
+  padding: 9px 11px
+  pointer-events: none
+  border: 1px solid #cbdad3
+  border-radius: 6px
+  background: rgba(255, 255, 255, 0.97)
+  color: #263a47
+  font-size: 0.7rem
+  line-height: 1.45
+  box-shadow: 0 7px 22px rgba(0, 27, 54, 0.13)
+
+  strong
+    display: block
+    max-width: 220px
+    overflow: hidden
+    margin-bottom: 3px
+    text-overflow: ellipsis
+    white-space: nowrap
+
+.landing-method
+  margin-top: 12px !important
+  color: #77858e
+  font-size: 0.7rem
+  line-height: 1.5
+
+.landing-leaderboard-list
+  border-top: 1px solid #e4ece8
+
+.landing-leaderboard-row
+  display: grid
+  grid-template-columns: 28px minmax(0, 1fr) 48px
+  gap: 9px
+  align-items: center
+  min-width: 0
+  padding: 13px 0
+  border-bottom: 1px solid #e4ece8
+  text-decoration: none
+
+  &:hover .landing-leaderboard-row__model strong
+    color: #087da6
+
+.landing-leaderboard-row__rank
+  display: inline-flex
+  align-items: center
+  justify-content: center
+  width: 24px
+  height: 24px
+  border-radius: 50%
+  background: #edf7f0
+  color: #147240
+  font-size: 0.69rem
+  font-weight: 800
+
+.landing-leaderboard-row__model
+  min-width: 0
+
+  strong, span
+    display: block
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
+
+  strong
+    font-size: 0.73rem
+    transition: color 120ms ease
+
+  span
+    margin-top: 3px
+    color: #7a8892
+    font-size: 0.63rem
+
+.landing-leaderboard-row__score
+  color: #147240
+  font-size: 0.82rem
+  font-variant-numeric: tabular-nums
+  font-weight: 800
+  text-align: right
+
+.landing-leaderboard-preview__footer
+  display: flex
+  flex-wrap: wrap
+  gap: 6px 15px
+  margin-top: 14px
+  color: #7b8992
+  font-size: 0.66rem
+
+.landing-compare__grid
+  display: grid
+  grid-template-columns: repeat(2, minmax(0, 1fr))
+  gap: 22px
+
+.landing-compare-card
+  display: grid
+  grid-template-columns: minmax(0, 1fr) 210px
+  gap: 30px
+  align-items: center
+  min-height: 285px
+  padding: 32px
+  overflow: hidden
+  border: 1px solid #dce8e2
+  border-top: 4px solid $brainscore_green
+  border-radius: 12px
+  background: white
+  text-decoration: none
+  box-shadow: 0 10px 28px rgba(0, 27, 54, 0.055)
+  transition: transform 180ms ease, box-shadow 180ms ease
+
+  &:hover
+    transform: translateY(-3px)
+    box-shadow: 0 17px 34px rgba(0, 27, 54, 0.1)
+
+  &.landing-compare-card--models
+    border-top-color: $brainscore_blue
+
+.landing-compare-card__copy
+  h3
+    margin-top: 14px
+    font-size: 1.45rem
+    line-height: 1.28
+
+  p
+    margin-top: 12px
+    color: #64747f
+    font-size: 0.83rem
+    line-height: 1.65
+
+.landing-card-link
+  display: inline-block
+  margin-top: 24px
+  color: #087da6
+  font-size: 0.82rem
+  font-weight: 800
+
+.landing-mini-matrix
+  display: grid
+  grid-template-columns: repeat(4, 37px)
+  grid-template-rows: repeat(4, 37px)
+  gap: 4px
+  justify-content: center
+  padding: 22px
+  border-radius: 14px
+  background: #f4f8f6
+  transform: rotate(-3deg)
+
+  span
+    border-radius: 4px
+    background: #f5efe4
+
+    &:nth-child(1), &:nth-child(6), &:nth-child(11), &:nth-child(16)
+      background: #168b4b
+    &:nth-child(2), &:nth-child(5), &:nth-child(12), &:nth-child(15)
+      background: #74c997
+    &:nth-child(3), &:nth-child(9), &:nth-child(8), &:nth-child(14)
+      background: #b8e3c8
+    &:nth-child(4), &:nth-child(7), &:nth-child(10), &:nth-child(13)
+      background: #e5d9d0
+
+.landing-mini-differences
+  display: flex
+  flex-direction: column
+  gap: 21px
+  padding: 25px 14px
+
+  span
+    position: relative
+    display: block
+    height: 2px
+    background: #d4ded9
+
+    &::before, &::after
+      content: ""
+      position: absolute
+      top: 50%
+      width: 7px
+      height: 7px
+      border-radius: 50%
+      background: #d4ded9
+      transform: translateY(-50%)
+
+    &::before
+      left: 0
+    &::after
+      right: 0
+
+    i, b
+      position: absolute
+      top: 50%
+      width: 13px
+      height: 13px
+      border: 3px solid white
+      border-radius: 50%
+      transform: translate(-50%, -50%)
+      box-shadow: 0 0 0 1px rgba(0, 27, 54, 0.08)
+
+    i
+      left: 28%
+      background: $brainscore_blue
+
+    b
+      left: 66%
+      background: $brainscore_green
+
+    &:nth-child(2) i
+      left: 45%
+    &:nth-child(2) b
+      left: 78%
+    &:nth-child(3) i
+      left: 67%
+    &:nth-child(3) b
+      left: 36%
+    &:nth-child(4) i
+      left: 22%
+    &:nth-child(4) b
+      left: 55%
+    &:nth-child(5) i
+      left: 75%
+    &:nth-child(5) b
+      left: 48%
+
+.landing-participate
+  display: grid
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr)
+  gap: 64px
+  align-items: center
+  margin-top: 92px
+  padding: 56px
+  border-radius: 14px
+  background: #092f31
+  color: white
+
+.landing-participate__code
+  overflow: hidden
+  border: 1px solid rgba(255, 255, 255, 0.15)
+  border-radius: 10px
+  background: #061f21
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.15)
+
+  pre
+    overflow-x: auto
+    margin: 0
+    padding: 26px
+    background: transparent
+    color: #d7e7e4
+    font-size: 0.75rem
+    line-height: 1.8
+
+  code span
+    color: #7cdda2
+
+.landing-code-heading
+  display: flex
+  justify-content: space-between
+  gap: 20px
+  padding: 11px 16px
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1)
+  color: #9cb8b5
+  font-size: 0.66rem
+
+  i
+    margin-right: 7px
+    color: #7cdda2
+
+.landing-participate__copy
+  .landing-eyebrow
+    color: #7cdda2
+
+  > p:not(.landing-eyebrow)
+    margin-top: 16px
+    color: #c6dbd8
+    font-size: 0.9rem
+    line-height: 1.7
+
+.landing-participate__actions
+  display: flex
+  flex-wrap: wrap
+  align-items: center
+  gap: 12px
+  margin-top: 25px
+
+  .landing-button--outline
+    border-color: rgba(255, 255, 255, 0.35)
+    background: transparent
+    color: white
+
+  .landing-text-link
+    margin-left: 5px
+    color: #9de5f3 !important
+
+.landing-footer
+  display: grid
+  grid-template-columns: 180px minmax(0, 1fr) auto
+  gap: 30px
+  align-items: center
+  margin-top: 26px
+  padding: 35px 42px
+  background: linear-gradient(110deg, #168b4b, #1598ba)
+  color: white
+
+  img
+    width: 155px
+
+  p
+    color: rgba(255, 255, 255, 0.84)
+    font-size: 0.76rem
+
+  nav
+    display: flex
+    flex-wrap: wrap
+    gap: 19px
+
+    a
+      color: white
+      font-size: 0.72rem
+      font-weight: 700
+
+.landing-empty
+  padding: 22px 0
+  color: #7d8a93
+  font-size: 0.8rem
+
+@media (max-width: 1215px)
+  .landing-opening, .landing-explore__grid
+    grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.8fr)
+
+  .landing-compare-card
+    grid-template-columns: minmax(0, 1fr) 145px
+    gap: 18px
+    padding: 26px
+
+  .landing-mini-matrix
+    grid-template-columns: repeat(4, 28px)
+    grid-template-rows: repeat(4, 28px)
+    padding: 15px
+
+@media (max-width: 1023px)
+  .landing-dashboard__intro
+    align-items: flex-start
+    flex-direction: column
+    gap: 18px
+
+  .landing-opening, .landing-explore__grid, .landing-participate
+    grid-template-columns: 1fr
+
+  .landing-onboarding
+    min-height: 450px
+
+  .landing-compare__grid
+    grid-template-columns: 1fr
+
+  .landing-compare-card
+    grid-template-columns: minmax(0, 1fr) 210px
+
+  .landing-footer
+    grid-template-columns: 160px 1fr
+
+    nav
+      grid-column: 1 / -1

--- a/static/benchmarks/css/landing_page.sass
+++ b/static/benchmarks/css/landing_page.sass
@@ -802,6 +802,19 @@ button.simple_button
   border-radius: 8px
   background: radial-gradient(circle at 48% 42%, rgba(69, 198, 118, 0.09), transparent 34%), radial-gradient(circle at 58% 58%, rgba(71, 183, 222, 0.08), transparent 42%), #fbfdfc
 
+  &.is-2d
+    background: linear-gradient(rgba(240, 246, 243, 0.7) 1px, transparent 1px), linear-gradient(90deg, rgba(240, 246, 243, 0.7) 1px, transparent 1px), #fcfefd
+    background-size: 54px 54px
+
+    .landing-space__axis
+      stroke: #aebdb6
+      stroke-width: 1
+
+    .landing-space__axis-label
+      fill: #687983
+      font-size: 11px
+      font-weight: 600
+
   svg
     display: block
     width: 100%
@@ -876,6 +889,9 @@ button.simple_button
   background: rgba(255, 255, 255, 0.88)
   backdrop-filter: blur(4px)
   color: #64757d
+
+  &[hidden]
+    display: none
 
   > span
     grid-column: 1 / -1

--- a/static/benchmarks/css/landing_page.sass
+++ b/static/benchmarks/css/landing_page.sass
@@ -370,7 +370,7 @@ button.simple_button
   padding-top: 114px
   color: $brainscore_gray4
   font-family: "Open Sans", sans-serif
-  background: radial-gradient(circle at 8% 4%, rgba(69, 198, 118, 0.08), transparent 25rem), radial-gradient(circle at 92% 28%, rgba(71, 183, 222, 0.07), transparent 28rem), #fbfdfc
+  background: radial-gradient(circle at 8% 4%, rgba(69, 198, 118, 0.1), transparent 25rem), radial-gradient(circle at 92% 28%, rgba(71, 183, 222, 0.09), transparent 28rem), linear-gradient(180deg, #fbfdfc 0%, #f1faf5 48%, #fbfdfc 100%)
 
   h1, h2, h3, p
     margin: 0
@@ -397,18 +397,126 @@ button.simple_button
     color: inherit
 
 .landing-dashboard__intro
-  display: flex
-  align-items: flex-end
-  justify-content: space-between
-  gap: 56px
-  padding: 54px 0 38px
+  position: relative
+  display: grid
+  grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr)
+  min-height: 390px
+  margin-top: 32px
+  margin-bottom: 26px
+  overflow: hidden
+  border: 1px solid rgba(69, 198, 118, 0.16)
+  border-radius: 32px
+  background: linear-gradient(118deg, rgba(211, 246, 224, 0.98) 0%, rgba(207, 242, 232, 0.94) 44%, rgba(199, 236, 247, 0.96) 100%)
+  box-shadow: 0 20px 54px rgba(20, 103, 78, 0.1)
 
-  > p
-    max-width: 470px
-    padding-bottom: 4px
-    color: #506272
-    font-size: 1.03rem
-    line-height: 1.7
+  &::after
+    content: ""
+    position: absolute
+    right: 27%
+    bottom: -84px
+    width: 240px
+    height: 240px
+    border: 1px solid rgba(255, 255, 255, 0.46)
+    border-radius: 50%
+
+.landing-hero__copy
+  position: relative
+  z-index: 2
+  display: flex
+  flex-direction: column
+  align-items: flex-start
+  justify-content: center
+  padding: 58px 24px 54px 7%
+
+.landing-hero__wordmark
+  width: clamp(245px, 30vw, 410px)
+  max-width: 88%
+  height: auto
+  margin-bottom: 18px
+
+.landing-hero__summary
+  max-width: 600px
+  margin-top: 19px !important
+  color: #405f6c
+  font-size: 1rem
+  line-height: 1.7
+
+.landing-hero__art
+  position: relative
+  z-index: 1
+  min-height: 390px
+
+  &::before
+    content: ""
+    position: absolute
+    inset: 28px 30px 28px 0
+    border: 1px solid rgba(255, 255, 255, 0.45)
+    border-radius: 50%
+
+  img
+    position: absolute
+    right: -12%
+    bottom: -6%
+    width: auto
+    height: 112%
+    max-width: none
+    opacity: 0.94
+
+.landing-bridge
+  display: grid
+  grid-template-columns: auto minmax(116px, 190px) auto
+  gap: 11px
+  align-items: center
+  width: min(100%, 510px)
+  margin-top: 32px
+
+.landing-bridge__endpoint
+  font-size: 0.67rem
+  font-weight: 800
+  letter-spacing: 0.08em
+  text-transform: uppercase
+
+  &.landing-bridge__endpoint--models
+    color: #1689b1
+
+  &.landing-bridge__endpoint--brain
+    color: #168b4b
+    text-align: right
+
+.landing-bridge__line
+  position: relative
+  display: block
+  height: 2px
+  background: linear-gradient(90deg, $brainscore_blue, #55c5a2 54%, $brainscore_green)
+
+  &::before, &::after
+    content: ""
+    position: absolute
+    top: 50%
+    width: 8px
+    height: 8px
+    border-radius: 50%
+    transform: translateY(-50%)
+
+  &::before
+    left: 0
+    background: $brainscore_blue
+
+  &::after
+    right: 0
+    background: $brainscore_green
+
+  img
+    position: absolute
+    top: 50%
+    left: 50%
+    width: 29px
+    height: 29px
+    padding: 5px
+    border-radius: 50%
+    background: rgba(255, 255, 255, 0.92)
+    transform: translate(-50%, -50%)
+    box-shadow: 0 4px 12px rgba(14, 92, 75, 0.14)
 
 .landing-eyebrow
   margin-bottom: 10px !important
@@ -421,20 +529,20 @@ button.simple_button
 .landing-button.button
   min-height: 42px
   padding: 0.65rem 1.15rem
-  border: 1px solid #168b4b
+  border: 1px solid transparent
   border-radius: 8px
-  background: #168b4b
+  background: linear-gradient(105deg, #35bf79, #36a9c8)
   color: white
   font-weight: 700
   box-shadow: none
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease
 
   &:hover, &:focus
-    border-color: #10783e
-    background: #10783e
+    border-color: transparent
+    background: linear-gradient(105deg, #24aa68, #2797b7)
     color: white
     transform: translateY(-1px)
-    box-shadow: 0 7px 18px rgba(22, 139, 75, 0.2)
+    box-shadow: 0 7px 18px rgba(31, 143, 139, 0.22)
 
   &.landing-button--compact
     min-height: 34px
@@ -443,13 +551,13 @@ button.simple_button
 
   &.landing-button--outline
     border-color: #b7c7c0
-    background: white
-    color: #116b3b
+    background: rgba(255, 255, 255, 0.74)
+    color: #1b708a
 
     &:hover, &:focus
-      border-color: #168b4b
-      background: #f4fbf7
-      color: #116b3b
+      border-color: #47b7de
+      background: rgba(255, 255, 255, 0.94)
+      color: #15647c
 
   &.landing-button--full
     width: 100%
@@ -467,11 +575,28 @@ button.simple_button
     text-decoration: underline
 
 .landing-panel
+  position: relative
+  overflow: hidden
   border: 1px solid #dce8e2
-  border-top: 4px solid $brainscore_green
   border-radius: 12px
   background: rgba(255, 255, 255, 0.94)
   box-shadow: 0 12px 32px rgba(0, 27, 54, 0.07)
+
+  &::before
+    content: ""
+    position: absolute
+    z-index: 2
+    top: 0
+    right: 0
+    left: 0
+    height: 4px
+    background: linear-gradient(90deg, $brainscore_green, $brainscore_blue)
+
+  &.landing-panel--models::before
+    background: $brainscore_blue
+
+  &.landing-panel--benchmarks::before
+    background: $brainscore_green
 
 .landing-opening
   display: grid
@@ -579,6 +704,7 @@ button.simple_button
   border-top: 1px solid #e4ece8
 
   h3
+    color: #1689b1
     font-size: 0.93rem
 
   a
@@ -602,7 +728,7 @@ button.simple_button
   text-decoration: none
 
   &:hover
-    background: #f2f8f5
+    background: #f1f8fb
 
   > time
     color: #83909a
@@ -614,10 +740,10 @@ button.simple_button
   justify-content: center
   width: 34px
   height: 34px
-  border: 1px solid #bce3ca
+  border: 1px solid #b9dfec
   border-radius: 50%
-  background: linear-gradient(145deg, #e6f8ec, #e4f4fb)
-  color: #12683a
+  background: #e9f6fb
+  color: #137d9f
   font-size: 0.67rem
   font-weight: 800
 
@@ -640,9 +766,11 @@ button.simple_button
     font-size: 0.67rem
 
 .landing-onboarding
+  position: relative
   display: flex
   flex-direction: column
   min-height: 100%
+  overflow: hidden
   padding: 30px
   border-radius: 12px
   background: linear-gradient(150deg, #082f2b 0%, #0a4a48 56%, #116879 100%)
@@ -650,30 +778,42 @@ button.simple_button
   box-shadow: 0 12px 32px rgba(0, 45, 51, 0.16)
 
   .landing-eyebrow
+    position: relative
+    z-index: 1
     color: #80e6a7
 
   h2
+    position: relative
+    z-index: 1
     max-width: 300px
     font-size: 1.85rem
 
   > p:not(.landing-eyebrow)
+    position: relative
+    z-index: 1
     margin-top: 15px
     color: #d4e9e6
     font-size: 0.88rem
     line-height: 1.65
 
   .landing-button
+    position: relative
+    z-index: 1
     margin-top: auto
     border-color: #6ed89a
     background: #6ed89a
     color: #07372a
 
   .landing-text-link
+    position: relative
+    z-index: 1
     justify-content: center
     margin-top: 15px
     color: #b8eaf1 !important
 
 .landing-onboarding__icon
+  position: relative
+  z-index: 1
   display: inline-flex
   align-items: center
   justify-content: center
@@ -709,6 +849,23 @@ button.simple_button
       color: #8aebaf
       font-size: 0.68rem
       font-weight: 800
+
+.landing-onboarding__network
+  position: absolute
+  right: -92px
+  bottom: -58px
+  width: 300px
+  pointer-events: none
+  opacity: 0.13
+  transform: rotate(-8deg)
+
+  img
+    display: block
+    width: 100%
+
+.landing-onboarding__steps
+  position: relative
+  z-index: 1
 
 .landing-explore, .landing-compare
   padding-top: 92px
@@ -965,8 +1122,8 @@ button.simple_button
   width: 24px
   height: 24px
   border-radius: 50%
-  background: #edf7f0
-  color: #147240
+  background: #eaf6fb
+  color: #137f9f
   font-size: 0.69rem
   font-weight: 800
 
@@ -989,7 +1146,7 @@ button.simple_button
     font-size: 0.63rem
 
 .landing-leaderboard-row__score
-  color: #147240
+  color: #137f9f
   font-size: 0.82rem
   font-variant-numeric: tabular-nums
   font-weight: 800
@@ -1004,6 +1161,8 @@ button.simple_button
   font-size: 0.66rem
 
 .landing-compare__grid
+  position: relative
+  z-index: 1
   display: grid
   grid-template-columns: repeat(2, minmax(0, 1fr))
   gap: 22px
@@ -1031,6 +1190,9 @@ button.simple_button
   &.landing-compare-card--models
     border-top-color: $brainscore_blue
 
+    .landing-card-link
+      color: #087da6
+
 .landing-compare-card__copy
   h3
     margin-top: 14px
@@ -1046,7 +1208,7 @@ button.simple_button
 .landing-card-link
   display: inline-block
   margin-top: 24px
-  color: #087da6
+  color: #168b4b
   font-size: 0.82rem
   font-weight: 800
 
@@ -1137,14 +1299,16 @@ button.simple_button
       left: 48%
 
 .landing-participate
+  position: relative
+  overflow: hidden
   display: grid
   grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr)
   gap: 64px
   align-items: center
   margin-top: 92px
   padding: 56px
-  border-radius: 14px
-  background: #092f31
+  border-radius: 24px
+  background: linear-gradient(125deg, #073b36 0%, #0b5254 54%, #126e82 100%)
   color: white
 
 .landing-participate__code
@@ -1212,7 +1376,8 @@ button.simple_button
   align-items: center
   margin-top: 26px
   padding: 35px 42px
-  background: linear-gradient(110deg, #168b4b, #1598ba)
+  border-radius: 24px 24px 0 0
+  background: linear-gradient(110deg, #2dbd74, #37aaca)
   color: white
 
   img
@@ -1253,9 +1418,15 @@ button.simple_button
 
 @media (max-width: 1023px)
   .landing-dashboard__intro
-    align-items: flex-start
-    flex-direction: column
-    gap: 18px
+    grid-template-columns: minmax(0, 1fr) minmax(285px, 0.72fr)
+
+  .landing-hero__copy
+    padding-left: 9%
+
+  .landing-hero__art img
+    right: -12%
+    width: auto
+    height: 108%
 
   .landing-opening, .landing-explore__grid, .landing-participate
     grid-template-columns: 1fr
@@ -1274,3 +1445,62 @@ button.simple_button
 
     nav
       grid-column: 1 / -1
+
+@media (max-width: 760px)
+  .landing-dashboard
+    padding-top: 88px
+
+  .landing-dashboard__intro
+    grid-template-columns: 1fr
+    min-height: 640px
+    margin-top: 18px
+    border-radius: 22px
+
+  .landing-hero__copy
+    justify-content: flex-start
+    padding: 38px 7% 265px
+
+  .landing-hero__wordmark
+    width: 275px
+
+  .landing-hero__summary
+    font-size: 0.9rem
+
+  .landing-hero__art
+    position: absolute
+    right: 0
+    bottom: 0
+    left: 0
+    min-height: 295px
+
+    img
+      right: -2%
+      bottom: -8%
+      width: auto
+      height: 112%
+
+  .landing-bridge
+    grid-template-columns: auto minmax(70px, 1fr) auto
+
+  .landing-opening
+    grid-template-columns: 1fr
+
+  .landing-update-grid, .landing-submission-list
+    grid-template-columns: 1fr
+
+  .landing-compare-card
+    grid-template-columns: 1fr
+
+  .landing-mini-matrix, .landing-mini-differences
+    display: none
+
+  .landing-participate
+    gap: 35px
+    padding: 34px 24px
+
+  .landing-footer
+    grid-template-columns: 1fr
+    padding: 32px 24px
+
+    nav
+      grid-column: auto

--- a/static/benchmarks/css/landing_page.sass
+++ b/static/benchmarks/css/landing_page.sass
@@ -732,23 +732,91 @@ button.simple_button
     margin-top: 8px
 
 .landing-card-heading__hint
-  margin-top: 4px
   color: #7a8993
   font-size: 0.69rem
+
+.landing-card-heading__tools
+  display: flex
+  align-items: center
+  gap: 10px
+  margin-top: 2px
+
+.landing-space-toggle
+  display: inline-flex
+  padding: 2px
+  border: 1px solid #cfddd6
+  border-radius: 7px
+  background: #f6faf8
+
+  button
+    min-width: 34px
+    height: 24px
+    padding: 0 8px
+    cursor: pointer
+    border: 0
+    border-radius: 5px
+    background: transparent
+    color: #6b7d78
+    font: inherit
+    font-size: 0.66rem
+    font-weight: 800
+
+    &[aria-pressed="true"]
+      background: white
+      color: #168b4b
+      box-shadow: 0 1px 4px rgba(0, 45, 51, 0.12)
+
+    &:focus-visible
+      outline: 2px solid rgba(22, 139, 75, 0.35)
+      outline-offset: 1px
+
+.landing-icon-button
+  display: inline-flex
+  align-items: center
+  justify-content: center
+  width: 30px
+  height: 30px
+  padding: 0
+  cursor: pointer
+  border: 1px solid #cfddd6
+  border-radius: 6px
+  background: white
+  color: #58706b
+  transition: border-color 140ms ease, color 140ms ease, background 140ms ease
+
+  &[hidden]
+    display: none
+
+  &:hover, &:focus
+    border-color: #168b4b
+    background: #f2faf5
+    color: #168b4b
+    outline: none
 
 .landing-space
   position: relative
   min-height: 390px
   overflow: hidden
+  user-select: none
   border: 1px solid #e1ebe6
   border-radius: 8px
-  background: linear-gradient(rgba(240, 246, 243, 0.7) 1px, transparent 1px), linear-gradient(90deg, rgba(240, 246, 243, 0.7) 1px, transparent 1px), #fcfefd
-  background-size: 54px 54px
+  background: radial-gradient(circle at 48% 42%, rgba(69, 198, 118, 0.09), transparent 34%), radial-gradient(circle at 58% 58%, rgba(71, 183, 222, 0.08), transparent 42%), #fbfdfc
 
   svg
     display: block
     width: 100%
     min-height: 390px
+    touch-action: none
+
+    &:focus
+      outline: 2px solid rgba(22, 139, 75, 0.32)
+      outline-offset: -2px
+
+    &.is-3d
+      cursor: grab
+
+    &.is-3d.is-dragging
+      cursor: grabbing
 
 .landing-space__empty
   display: flex
@@ -759,18 +827,31 @@ button.simple_button
   font-size: 0.84rem
 
 .landing-space__axis
-  stroke: #aebdb6
-  stroke-width: 1
+  stroke: #168b4b
+  stroke-linecap: round
+  stroke-width: 1.35
+
+  &.landing-space__axis--2
+    stroke: #279fc8
+
+  &.landing-space__axis--3
+    stroke: #778c97
+
+.landing-space__grid-line
+  stroke: #d9e4de
+  stroke-width: 0.75
 
 .landing-space__axis-label
-  fill: #687983
-  font-size: 11px
-  font-weight: 600
+  fill: #526a72
+  font-size: 10px
+  font-weight: 700
+  paint-order: stroke
+  stroke: rgba(255, 255, 255, 0.94)
+  stroke-linejoin: round
+  stroke-width: 3px
 
 .landing-space__point
   cursor: pointer
-  opacity: 0
-  animation: landing-point-in 400ms ease forwards
   transition: r 120ms ease, opacity 120ms ease, stroke-width 120ms ease
 
   &:hover, &:focus
@@ -779,11 +860,43 @@ button.simple_button
     stroke-width: 2.5
     outline: none
 
-@keyframes landing-point-in
-  from
-    opacity: 0
-  to
-    opacity: 0.76
+.landing-space__legend
+  position: absolute
+  right: 13px
+  bottom: 11px
+  z-index: 1
+  display: grid
+  grid-template-columns: auto 1fr auto
+  gap: 3px 6px
+  align-items: center
+  padding: 7px 9px
+  pointer-events: none
+  border: 1px solid rgba(207, 221, 214, 0.88)
+  border-radius: 6px
+  background: rgba(255, 255, 255, 0.88)
+  backdrop-filter: blur(4px)
+  color: #64757d
+
+  > span
+    grid-column: 1 / -1
+    font-size: 0.61rem
+    font-weight: 700
+
+  > i
+    display: block
+    grid-column: 1 / -1
+    width: 84px
+    height: 5px
+    border-radius: 999px
+    background: linear-gradient(90deg, $brainscore_blue, #5dbf9c, #168b4b)
+
+  > small
+    color: #7b8990
+    font-size: 0.52rem
+
+    &:last-child
+      grid-column: 3
+      text-align: right
 
 .landing-space__tooltip
   position: absolute

--- a/static/benchmarks/js/landing-dashboard.js
+++ b/static/benchmarks/js/landing-dashboard.js
@@ -20,6 +20,21 @@
         return Math.max(minimum, Math.min(maximum, value));
     }
 
+    function paddedExtent(values) {
+        var sorted = values.slice().sort(function (left, right) { return left - right; });
+        var trim = sorted.length >= 20 ? Math.floor(sorted.length * 0.025) : 0;
+        var bounds = [sorted[trim], sorted[sorted.length - trim - 1]];
+        var range = bounds[1] - bounds[0];
+        var padding = range > 0 ? range * 0.12 : 1;
+        return [bounds[0] - padding, bounds[1] + padding];
+    }
+
+    function scale(value, domain, output) {
+        if (domain[0] === domain[1]) return (output[0] + output[1]) / 2;
+        var ratio = clamp((value - domain[0]) / (domain[1] - domain[0]), 0, 1);
+        return output[0] + ratio * (output[1] - output[0]);
+    }
+
     function pointColor(score, scoreExtent) {
         if (!Number.isFinite(score)) return '#7eb7a0';
         var ratio = scoreExtent[0] === scoreExtent[1]
@@ -104,10 +119,10 @@
         var dimensions = {centerX: 377, centerY: 194, scale: 120};
         var camera = {yaw: DEFAULT_CAMERA.yaw, pitch: DEFAULT_CAMERA.pitch};
         var mode = container.dataset.spaceMode === '3d' ? '3d' : '2d';
-        var coordinateLimits = {
-            '2d': robustCoordinateLimit(points, '2d'),
-            '3d': robustCoordinateLimit(points, '3d')
-        };
+        var coordinateLimit3d = robustCoordinateLimit(points, '3d');
+        var twoDimensionalMargin = {top: 24, right: 26, bottom: 49, left: 54};
+        var xDomain = paddedExtent(points.map(function (point) { return point.x; }));
+        var yDomain = paddedExtent(points.map(function (point) { return point.y; }));
         var finiteScores = points
             .map(function (point) { return Number(point.score); })
             .filter(Number.isFinite);
@@ -143,18 +158,6 @@
                 var line = svgElement('line', {class: 'landing-space__grid-line'});
                 gridGroup.appendChild(line);
                 gridLines3d.push({line: line, start: endpoints[0], end: endpoints[1]});
-            });
-        });
-
-        var gridLines2d = [];
-        [-1, -0.5, 0, 0.5, 1].forEach(function (position) {
-            [
-                [{x: -1, y: position, z: 0}, {x: 1, y: position, z: 0}],
-                [{x: position, y: -1, z: 0}, {x: position, y: 1, z: 0}]
-            ].forEach(function (endpoints) {
-                var line = svgElement('line', {class: 'landing-space__grid-line'});
-                gridGroup.appendChild(line);
-                gridLines2d.push({line: line, start: endpoints[0], end: endpoints[1]});
             });
         });
 
@@ -208,15 +211,10 @@
             return {
                 point: point,
                 circle: circle,
-                coordinates2d: {
-                    x: normalizedCoordinate(point.x, coordinateLimits['2d']),
-                    y: normalizedCoordinate(point.y, coordinateLimits['2d']),
-                    z: 0
-                },
                 coordinates3d: {
-                    x: normalizedCoordinate(point.x, coordinateLimits['3d']),
-                    y: normalizedCoordinate(point.y, coordinateLimits['3d']),
-                    z: normalizedCoordinate(point.z, coordinateLimits['3d'])
+                    x: normalizedCoordinate(point.x, coordinateLimit3d),
+                    y: normalizedCoordinate(point.y, coordinateLimit3d),
+                    z: normalizedCoordinate(point.z, coordinateLimit3d)
                 }
             };
         });
@@ -237,46 +235,75 @@
             tooltip.style.top = top + 'px';
         }
 
-        function sceneProjection(point) {
-            if (mode === '2d') {
-                var twoDimensionalScale = 150;
-                return {
-                    x: dimensions.centerX + point.x * twoDimensionalScale,
-                    y: dimensions.centerY - point.y * twoDimensionalScale,
-                    z: 0,
-                    perspective: 1
-                };
-            }
-            return projectPoint(point, camera, dimensions);
-        }
-
-        function renderScene() {
-            gridLines2d.forEach(function (gridLine) {
-                gridLine.line.hidden = mode !== '2d';
-                setLine(gridLine.line, sceneProjection(gridLine.start), sceneProjection(gridLine.end));
-            });
+        function renderTwoDimensionalScene() {
             gridLines3d.forEach(function (gridLine) {
-                gridLine.line.hidden = mode !== '3d';
-                setLine(
-                    gridLine.line,
-                    sceneProjection(gridLine.start),
-                    sceneProjection(gridLine.end)
-                );
+                gridLine.line.hidden = true;
             });
-            var activeOrigin = mode === '2d' ? {x: -1, y: -1, z: 0} : axisOrigin;
-            var origin = sceneProjection(activeOrigin);
+            var xAxisY = height - twoDimensionalMargin.bottom;
             axes.forEach(function (axis) {
-                var endpointDefinition = mode === '2d'
-                    ? [
-                        {x: 1.08, y: -1, z: 0},
-                        {x: -1, y: 1.08, z: 0}
-                    ][axis.index]
-                    : axis.end;
-                var isVisible = mode === '3d' || axis.index < 2;
+                var isVisible = axis.index < 2;
                 axis.line.hidden = !isVisible;
                 axis.label.hidden = !isVisible;
                 if (!isVisible) return;
-                var endpoint = sceneProjection(endpointDefinition);
+                axis.label.removeAttribute('transform');
+                if (axis.index === 0) {
+                    setLine(
+                        axis.line,
+                        {x: twoDimensionalMargin.left, y: xAxisY},
+                        {x: width - twoDimensionalMargin.right, y: xAxisY}
+                    );
+                    axis.label.textContent = 'PC1 (' + variance[0] + '% variance)';
+                    axis.label.setAttribute('x', width / 2);
+                    axis.label.setAttribute('y', height - 12);
+                } else {
+                    setLine(
+                        axis.line,
+                        {x: twoDimensionalMargin.left, y: twoDimensionalMargin.top},
+                        {x: twoDimensionalMargin.left, y: xAxisY}
+                    );
+                    axis.label.textContent = 'PC2 (' + variance[1] + '% variance)';
+                    axis.label.setAttribute('x', 15);
+                    axis.label.setAttribute('y', height / 2);
+                    axis.label.setAttribute('transform', 'rotate(-90 15 ' + (height / 2) + ')');
+                }
+            });
+
+            scenePoints.slice().sort(function (left, right) {
+                return right.point.rank - left.point.rank;
+            }).forEach(function (scenePoint) {
+                var point = scenePoint.point;
+                scenePoint.circle.setAttribute('cx', scale(
+                    point.x,
+                    xDomain,
+                    [twoDimensionalMargin.left, width - twoDimensionalMargin.right]
+                ));
+                scenePoint.circle.setAttribute('cy', scale(
+                    point.y,
+                    yDomain,
+                    [xAxisY, twoDimensionalMargin.top]
+                ));
+                scenePoint.circle.setAttribute('r', point.rank <= 5 ? 6 : 4.5);
+                scenePoint.circle.setAttribute('opacity', 0.78);
+                pointsGroup.appendChild(scenePoint.circle);
+            });
+        }
+
+        function renderThreeDimensionalScene() {
+            gridLines3d.forEach(function (gridLine) {
+                gridLine.line.hidden = false;
+                setLine(
+                    gridLine.line,
+                    projectPoint(gridLine.start, camera, dimensions),
+                    projectPoint(gridLine.end, camera, dimensions)
+                );
+            });
+            var origin = projectPoint(axisOrigin, camera, dimensions);
+            axes.forEach(function (axis) {
+                axis.line.hidden = false;
+                axis.label.hidden = false;
+                axis.label.removeAttribute('transform');
+                axis.label.textContent = axisDefinitions[axis.index].label;
+                var endpoint = projectPoint(axis.end, camera, dimensions);
                 setLine(axis.line, origin, endpoint);
                 var xOffset = axis.index === 0 ? 7 : axis.index === 2 ? -5 : 0;
                 var yOffset = axis.index === 1 ? -8 : 15;
@@ -287,9 +314,7 @@
             var projectedPoints = scenePoints.map(function (scenePoint) {
                 return {
                     scenePoint: scenePoint,
-                    projected: sceneProjection(
-                        mode === '2d' ? scenePoint.coordinates2d : scenePoint.coordinates3d
-                    )
+                    projected: projectPoint(scenePoint.coordinates3d, camera, dimensions)
                 };
             }).sort(function (left, right) {
                 return left.projected.z - right.projected.z;
@@ -298,14 +323,19 @@
             projectedPoints.forEach(function (item) {
                 var point = item.scenePoint.point;
                 var projected = item.projected;
-                var depthRatio = mode === '2d' ? 0.72 : clamp((projected.z + 1.4) / 2.8, 0, 1);
+                var depthRatio = clamp((projected.z + 1.4) / 2.8, 0, 1);
                 var baseRadius = point.rank <= 5 ? 5.8 : 4.2;
                 item.scenePoint.circle.setAttribute('cx', projected.x);
                 item.scenePoint.circle.setAttribute('cy', projected.y);
                 item.scenePoint.circle.setAttribute('r', baseRadius * projected.perspective * (0.82 + depthRatio * 0.32));
-                item.scenePoint.circle.setAttribute('opacity', mode === '2d' ? 0.78 : 0.48 + depthRatio * 0.43);
+                item.scenePoint.circle.setAttribute('opacity', 0.48 + depthRatio * 0.43);
                 pointsGroup.appendChild(item.scenePoint.circle);
             });
+        }
+
+        function renderScene() {
+            if (mode === '2d') renderTwoDimensionalScene();
+            else renderThreeDimensionalScene();
         }
 
         scenePoints.forEach(function (scenePoint) {
@@ -420,6 +450,8 @@
                 ? 'Interactive three-dimensional principal component map. Drag or use the arrow keys to rotate. Select a point to open its model page.'
                 : 'Two-dimensional principal component map. Select a point to open its model page.');
             svg.classList.toggle('is-3d', mode === '3d');
+            container.classList.toggle('is-2d', mode === '2d');
+            legend.hidden = mode === '2d';
             renderScene();
         }
 

--- a/static/benchmarks/js/landing-dashboard.js
+++ b/static/benchmarks/js/landing-dashboard.js
@@ -1,0 +1,201 @@
+(function () {
+    'use strict';
+
+    var SVG_NS = 'http://www.w3.org/2000/svg';
+
+    function svgElement(name, attributes) {
+        var element = document.createElementNS(SVG_NS, name);
+        Object.keys(attributes || {}).forEach(function (key) {
+            element.setAttribute(key, attributes[key]);
+        });
+        return element;
+    }
+
+    function extent(values) {
+        return [Math.min.apply(null, values), Math.max.apply(null, values)];
+    }
+
+    function paddedExtent(values) {
+        var sorted = values.slice().sort(function (left, right) { return left - right; });
+        var trim = sorted.length >= 20 ? Math.floor(sorted.length * 0.025) : 0;
+        var bounds = [sorted[trim], sorted[sorted.length - trim - 1]];
+        var range = bounds[1] - bounds[0];
+        var padding = range > 0 ? range * 0.12 : 1;
+        return [bounds[0] - padding, bounds[1] + padding];
+    }
+
+    function scale(value, domain, output) {
+        if (domain[0] === domain[1]) return (output[0] + output[1]) / 2;
+        var ratio = (value - domain[0]) / (domain[1] - domain[0]);
+        ratio = Math.max(0, Math.min(1, ratio));
+        return output[0] + ratio * (output[1] - output[0]);
+    }
+
+    function pointColor(score, scoreExtent) {
+        if (!Number.isFinite(score)) return '#7eb7a0';
+        var ratio = scoreExtent[0] === scoreExtent[1]
+            ? 0.5
+            : (score - scoreExtent[0]) / (scoreExtent[1] - scoreExtent[0]);
+        ratio = Math.max(0, Math.min(1, ratio));
+        var start = [71, 183, 222];
+        var end = [22, 139, 75];
+        var channels = start.map(function (value, index) {
+            return Math.round(value + (end[index] - value) * ratio);
+        });
+        return 'rgb(' + channels.join(',') + ')';
+    }
+
+    function addAxisLabel(svg, text, x, y, transform) {
+        var label = svgElement('text', {
+            x: x,
+            y: y,
+            class: 'landing-space__axis-label',
+            'text-anchor': 'middle'
+        });
+        if (transform) label.setAttribute('transform', transform);
+        label.textContent = text;
+        svg.appendChild(label);
+    }
+
+    function renderBenchmarkSpace() {
+        var container = document.getElementById('landing-benchmark-space');
+        var dataElement = document.getElementById('landing-benchmark-space-data');
+        if (!container || !dataElement) return;
+
+        var data;
+        try {
+            data = JSON.parse(dataElement.textContent);
+        } catch (error) {
+            data = null;
+        }
+        var points = data && Array.isArray(data.points) ? data.points : [];
+        if (points.length < 3) {
+            container.innerHTML = '<div class="landing-space__empty">Benchmark-space data is temporarily unavailable.</div>';
+            return;
+        }
+
+        container.innerHTML = '';
+        var width = 760;
+        var height = 390;
+        var margin = {top: 24, right: 26, bottom: 49, left: 54};
+        var svg = svgElement('svg', {
+            viewBox: '0 0 ' + width + ' ' + height,
+            preserveAspectRatio: 'xMidYMid meet',
+            role: 'group',
+            'aria-label': 'Interactive principal component map. Select a point to open its model page.'
+        });
+        var xDomain = paddedExtent(points.map(function (point) { return point.x; }));
+        var yDomain = paddedExtent(points.map(function (point) { return point.y; }));
+        var finiteScores = points
+            .map(function (point) { return Number(point.score); })
+            .filter(Number.isFinite);
+        var scoreExtent = finiteScores.length ? extent(finiteScores) : [0, 1];
+
+        var xAxisY = height - margin.bottom;
+        svg.appendChild(svgElement('line', {
+            x1: margin.left,
+            y1: xAxisY,
+            x2: width - margin.right,
+            y2: xAxisY,
+            class: 'landing-space__axis'
+        }));
+        svg.appendChild(svgElement('line', {
+            x1: margin.left,
+            y1: margin.top,
+            x2: margin.left,
+            y2: xAxisY,
+            class: 'landing-space__axis'
+        }));
+
+        var variance = data.variance || [0, 0];
+        addAxisLabel(svg, 'PC1 (' + variance[0] + '% variance)', width / 2, height - 12);
+        addAxisLabel(
+            svg,
+            'PC2 (' + variance[1] + '% variance)',
+            15,
+            height / 2,
+            'rotate(-90 15 ' + (height / 2) + ')'
+        );
+
+        var tooltip = document.createElement('div');
+        tooltip.className = 'landing-space__tooltip';
+        tooltip.hidden = true;
+        container.appendChild(svg);
+        container.appendChild(tooltip);
+
+        function showTooltip(point, clientX, clientY) {
+            var score = Number(point.score);
+            tooltip.innerHTML = '<strong></strong><span></span>';
+            tooltip.querySelector('strong').textContent = point.name;
+            tooltip.querySelector('span').textContent =
+                'Rank ' + point.rank + (Number.isFinite(score) ? ' · Brain-Score ' + score.toFixed(3) : '');
+            tooltip.hidden = false;
+            var bounds = container.getBoundingClientRect();
+            var left = clientX - bounds.left + 12;
+            var top = clientY - bounds.top + 12;
+            if (left > bounds.width - 250) left = Math.max(8, left - 250);
+            if (top > bounds.height - 75) top = Math.max(8, top - 75);
+            tooltip.style.left = left + 'px';
+            tooltip.style.top = top + 'px';
+        }
+
+        points.slice().sort(function (left, right) {
+            return right.rank - left.rank;
+        }).forEach(function (point, index) {
+            var cx = scale(point.x, xDomain, [margin.left, width - margin.right]);
+            var cy = scale(point.y, yDomain, [xAxisY, margin.top]);
+            var topModel = point.rank <= 5;
+            var circle = svgElement('circle', {
+                cx: cx,
+                cy: cy,
+                r: topModel ? 6 : 4.5,
+                fill: pointColor(Number(point.score), scoreExtent),
+                stroke: topModel ? '#ffffff' : 'rgba(255,255,255,0.75)',
+                'stroke-width': topModel ? 2 : 1,
+                class: 'landing-space__point',
+                tabindex: '0',
+                'aria-label': point.name + ', rank ' + point.rank,
+                style: 'animation-delay:' + Math.min(index * 12, 450) + 'ms'
+            });
+            var title = svgElement('title');
+            title.textContent = point.name + ', rank ' + point.rank;
+            circle.appendChild(title);
+            circle.addEventListener('mousemove', function (event) {
+                showTooltip(point, event.clientX, event.clientY);
+            });
+            circle.addEventListener('mouseenter', function (event) {
+                showTooltip(point, event.clientX, event.clientY);
+            });
+            circle.addEventListener('mouseleave', function () {
+                tooltip.hidden = true;
+            });
+            circle.addEventListener('focus', function () {
+                var bounds = container.getBoundingClientRect();
+                showTooltip(
+                    point,
+                    bounds.left + (cx / width) * bounds.width,
+                    bounds.top + (cy / height) * bounds.height
+                );
+            });
+            circle.addEventListener('blur', function () {
+                tooltip.hidden = true;
+            });
+            circle.addEventListener('click', function () {
+                window.location.assign('/model/vision/' + point.id);
+            });
+            circle.addEventListener('keydown', function (event) {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    window.location.assign('/model/vision/' + point.id);
+                }
+            });
+            svg.appendChild(circle);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', renderBenchmarkSpace);
+    } else {
+        renderBenchmarkSpace();
+    }
+})();

--- a/static/benchmarks/js/landing-dashboard.js
+++ b/static/benchmarks/js/landing-dashboard.js
@@ -2,6 +2,7 @@
     'use strict';
 
     var SVG_NS = 'http://www.w3.org/2000/svg';
+    var DEFAULT_CAMERA = {yaw: -0.68, pitch: -0.34};
 
     function svgElement(name, attributes) {
         var element = document.createElementNS(SVG_NS, name);
@@ -15,20 +16,8 @@
         return [Math.min.apply(null, values), Math.max.apply(null, values)];
     }
 
-    function paddedExtent(values) {
-        var sorted = values.slice().sort(function (left, right) { return left - right; });
-        var trim = sorted.length >= 20 ? Math.floor(sorted.length * 0.025) : 0;
-        var bounds = [sorted[trim], sorted[sorted.length - trim - 1]];
-        var range = bounds[1] - bounds[0];
-        var padding = range > 0 ? range * 0.12 : 1;
-        return [bounds[0] - padding, bounds[1] + padding];
-    }
-
-    function scale(value, domain, output) {
-        if (domain[0] === domain[1]) return (output[0] + output[1]) / 2;
-        var ratio = (value - domain[0]) / (domain[1] - domain[0]);
-        ratio = Math.max(0, Math.min(1, ratio));
-        return output[0] + ratio * (output[1] - output[0]);
+    function clamp(value, minimum, maximum) {
+        return Math.max(minimum, Math.min(maximum, value));
     }
 
     function pointColor(score, scoreExtent) {
@@ -36,7 +25,7 @@
         var ratio = scoreExtent[0] === scoreExtent[1]
             ? 0.5
             : (score - scoreExtent[0]) / (scoreExtent[1] - scoreExtent[0]);
-        ratio = Math.max(0, Math.min(1, ratio));
+        ratio = clamp(ratio, 0, 1);
         var start = [71, 183, 222];
         var end = [22, 139, 75];
         var channels = start.map(function (value, index) {
@@ -45,16 +34,47 @@
         return 'rgb(' + channels.join(',') + ')';
     }
 
-    function addAxisLabel(svg, text, x, y, transform) {
-        var label = svgElement('text', {
-            x: x,
-            y: y,
-            class: 'landing-space__axis-label',
-            'text-anchor': 'middle'
+    function robustCoordinateLimit(points, mode) {
+        var coordinates = [];
+        points.forEach(function (point) {
+            coordinates.push(Math.abs(point.x), Math.abs(point.y));
+            if (mode === '3d') coordinates.push(Math.abs(point.z));
         });
-        if (transform) label.setAttribute('transform', transform);
-        label.textContent = text;
-        svg.appendChild(label);
+        coordinates.sort(function (left, right) { return left - right; });
+        var index = Math.min(coordinates.length - 1, Math.floor(coordinates.length * 0.975));
+        return Math.max(0.1, coordinates[index]);
+    }
+
+    function rotatePoint(point, camera) {
+        var cosYaw = Math.cos(camera.yaw);
+        var sinYaw = Math.sin(camera.yaw);
+        var cosPitch = Math.cos(camera.pitch);
+        var sinPitch = Math.sin(camera.pitch);
+        var yawX = point.x * cosYaw + point.z * sinYaw;
+        var yawZ = -point.x * sinYaw + point.z * cosYaw;
+        return {
+            x: yawX,
+            y: point.y * cosPitch - yawZ * sinPitch,
+            z: point.y * sinPitch + yawZ * cosPitch
+        };
+    }
+
+    function projectPoint(point, camera, dimensions) {
+        var rotated = rotatePoint(point, camera);
+        var perspective = 4.8 / (4.8 - rotated.z * 0.55);
+        return {
+            x: dimensions.centerX + rotated.x * dimensions.scale * perspective,
+            y: dimensions.centerY - rotated.y * dimensions.scale * perspective,
+            z: rotated.z,
+            perspective: perspective
+        };
+    }
+
+    function setLine(line, start, end) {
+        line.setAttribute('x1', start.x);
+        line.setAttribute('y1', start.y);
+        line.setAttribute('x2', end.x);
+        line.setAttribute('y2', end.y);
     }
 
     function renderBenchmarkSpace() {
@@ -68,7 +88,11 @@
         } catch (error) {
             data = null;
         }
-        var points = data && Array.isArray(data.points) ? data.points : [];
+        var points = data && Array.isArray(data.points)
+            ? data.points.filter(function (point) {
+                return Number.isFinite(point.x) && Number.isFinite(point.y) && Number.isFinite(point.z);
+            })
+            : [];
         if (points.length < 3) {
             container.innerHTML = '<div class="landing-space__empty">Benchmark-space data is temporarily unavailable.</div>';
             return;
@@ -77,51 +101,125 @@
         container.innerHTML = '';
         var width = 760;
         var height = 390;
-        var margin = {top: 24, right: 26, bottom: 49, left: 54};
-        var svg = svgElement('svg', {
-            viewBox: '0 0 ' + width + ' ' + height,
-            preserveAspectRatio: 'xMidYMid meet',
-            role: 'group',
-            'aria-label': 'Interactive principal component map. Select a point to open its model page.'
-        });
-        var xDomain = paddedExtent(points.map(function (point) { return point.x; }));
-        var yDomain = paddedExtent(points.map(function (point) { return point.y; }));
+        var dimensions = {centerX: 377, centerY: 194, scale: 120};
+        var camera = {yaw: DEFAULT_CAMERA.yaw, pitch: DEFAULT_CAMERA.pitch};
+        var mode = container.dataset.spaceMode === '3d' ? '3d' : '2d';
+        var coordinateLimits = {
+            '2d': robustCoordinateLimit(points, '2d'),
+            '3d': robustCoordinateLimit(points, '3d')
+        };
         var finiteScores = points
             .map(function (point) { return Number(point.score); })
             .filter(Number.isFinite);
         var scoreExtent = finiteScores.length ? extent(finiteScores) : [0, 1];
+        var variance = data.variance || [0, 0, 0];
+        var dragging = false;
+        var dragMoved = false;
+        var suppressClick = false;
+        var lastPointer = {x: 0, y: 0};
 
-        var xAxisY = height - margin.bottom;
-        svg.appendChild(svgElement('line', {
-            x1: margin.left,
-            y1: xAxisY,
-            x2: width - margin.right,
-            y2: xAxisY,
-            class: 'landing-space__axis'
-        }));
-        svg.appendChild(svgElement('line', {
-            x1: margin.left,
-            y1: margin.top,
-            x2: margin.left,
-            y2: xAxisY,
-            class: 'landing-space__axis'
-        }));
+        var svg = svgElement('svg', {
+            viewBox: '0 0 ' + width + ' ' + height,
+            preserveAspectRatio: 'xMidYMid meet',
+            role: 'group',
+            tabindex: '0',
+            'aria-label': 'Two-dimensional principal component map. Select a point to open its model page.'
+        });
+        var gridGroup = svgElement('g', {class: 'landing-space__grid'});
+        var axesGroup = svgElement('g', {class: 'landing-space__axes'});
+        var pointsGroup = svgElement('g', {class: 'landing-space__points'});
+        var labelsGroup = svgElement('g', {class: 'landing-space__labels'});
+        svg.appendChild(gridGroup);
+        svg.appendChild(axesGroup);
+        svg.appendChild(pointsGroup);
+        svg.appendChild(labelsGroup);
 
-        var variance = data.variance || [0, 0];
-        addAxisLabel(svg, 'PC1 (' + variance[0] + '% variance)', width / 2, height - 12);
-        addAxisLabel(
-            svg,
-            'PC2 (' + variance[1] + '% variance)',
-            15,
-            height / 2,
-            'rotate(-90 15 ' + (height / 2) + ')'
-        );
+        var gridLines3d = [];
+        [-1, -0.5, 0, 0.5, 1].forEach(function (position) {
+            [
+                [{x: -1, y: -1, z: position}, {x: 1, y: -1, z: position}],
+                [{x: position, y: -1, z: -1}, {x: position, y: -1, z: 1}]
+            ].forEach(function (endpoints) {
+                var line = svgElement('line', {class: 'landing-space__grid-line'});
+                gridGroup.appendChild(line);
+                gridLines3d.push({line: line, start: endpoints[0], end: endpoints[1]});
+            });
+        });
+
+        var gridLines2d = [];
+        [-1, -0.5, 0, 0.5, 1].forEach(function (position) {
+            [
+                [{x: -1, y: position, z: 0}, {x: 1, y: position, z: 0}],
+                [{x: position, y: -1, z: 0}, {x: position, y: 1, z: 0}]
+            ].forEach(function (endpoints) {
+                var line = svgElement('line', {class: 'landing-space__grid-line'});
+                gridGroup.appendChild(line);
+                gridLines2d.push({line: line, start: endpoints[0], end: endpoints[1]});
+            });
+        });
+
+        var axisOrigin = {x: -1, y: -1, z: -1};
+        var axisDefinitions = [
+            {end: {x: 1.08, y: -1, z: -1}, label: 'PC1 · ' + variance[0] + '%'},
+            {end: {x: -1, y: 1.08, z: -1}, label: 'PC2 · ' + variance[1] + '%'},
+            {end: {x: -1, y: -1, z: 1.08}, label: 'PC3 · ' + variance[2] + '%'}
+        ];
+        var axes = axisDefinitions.map(function (definition, index) {
+            var line = svgElement('line', {
+                class: 'landing-space__axis landing-space__axis--' + (index + 1)
+            });
+            var label = svgElement('text', {
+                class: 'landing-space__axis-label',
+                'text-anchor': 'middle'
+            });
+            label.textContent = definition.label;
+            axesGroup.appendChild(line);
+            labelsGroup.appendChild(label);
+            return {line: line, label: label, end: definition.end, index: index};
+        });
 
         var tooltip = document.createElement('div');
         tooltip.className = 'landing-space__tooltip';
         tooltip.hidden = true;
+        var legend = document.createElement('div');
+        legend.className = 'landing-space__legend';
+        legend.innerHTML = '<span>Brain-Score</span><i aria-hidden="true"></i><small>Lower</small><small>Higher</small>';
         container.appendChild(svg);
         container.appendChild(tooltip);
+        container.appendChild(legend);
+
+        function normalizedCoordinate(value, coordinateLimit) {
+            return clamp(value / coordinateLimit, -1.18, 1.18);
+        }
+
+        var scenePoints = points.map(function (point) {
+            var circle = svgElement('circle', {
+                fill: pointColor(Number(point.score), scoreExtent),
+                stroke: point.rank <= 5 ? '#ffffff' : 'rgba(255,255,255,0.82)',
+                'stroke-width': point.rank <= 5 ? 2.2 : 1,
+                class: 'landing-space__point',
+                tabindex: '0',
+                'aria-label': point.name + ', rank ' + point.rank
+            });
+            var title = svgElement('title');
+            title.textContent = point.name + ', rank ' + point.rank;
+            circle.appendChild(title);
+            pointsGroup.appendChild(circle);
+            return {
+                point: point,
+                circle: circle,
+                coordinates2d: {
+                    x: normalizedCoordinate(point.x, coordinateLimits['2d']),
+                    y: normalizedCoordinate(point.y, coordinateLimits['2d']),
+                    z: 0
+                },
+                coordinates3d: {
+                    x: normalizedCoordinate(point.x, coordinateLimits['3d']),
+                    y: normalizedCoordinate(point.y, coordinateLimits['3d']),
+                    z: normalizedCoordinate(point.z, coordinateLimits['3d'])
+                }
+            };
+        });
 
         function showTooltip(point, clientX, clientY) {
             var score = Number(point.score);
@@ -139,27 +237,80 @@
             tooltip.style.top = top + 'px';
         }
 
-        points.slice().sort(function (left, right) {
-            return right.rank - left.rank;
-        }).forEach(function (point, index) {
-            var cx = scale(point.x, xDomain, [margin.left, width - margin.right]);
-            var cy = scale(point.y, yDomain, [xAxisY, margin.top]);
-            var topModel = point.rank <= 5;
-            var circle = svgElement('circle', {
-                cx: cx,
-                cy: cy,
-                r: topModel ? 6 : 4.5,
-                fill: pointColor(Number(point.score), scoreExtent),
-                stroke: topModel ? '#ffffff' : 'rgba(255,255,255,0.75)',
-                'stroke-width': topModel ? 2 : 1,
-                class: 'landing-space__point',
-                tabindex: '0',
-                'aria-label': point.name + ', rank ' + point.rank,
-                style: 'animation-delay:' + Math.min(index * 12, 450) + 'ms'
+        function sceneProjection(point) {
+            if (mode === '2d') {
+                var twoDimensionalScale = 150;
+                return {
+                    x: dimensions.centerX + point.x * twoDimensionalScale,
+                    y: dimensions.centerY - point.y * twoDimensionalScale,
+                    z: 0,
+                    perspective: 1
+                };
+            }
+            return projectPoint(point, camera, dimensions);
+        }
+
+        function renderScene() {
+            gridLines2d.forEach(function (gridLine) {
+                gridLine.line.hidden = mode !== '2d';
+                setLine(gridLine.line, sceneProjection(gridLine.start), sceneProjection(gridLine.end));
             });
-            var title = svgElement('title');
-            title.textContent = point.name + ', rank ' + point.rank;
-            circle.appendChild(title);
+            gridLines3d.forEach(function (gridLine) {
+                gridLine.line.hidden = mode !== '3d';
+                setLine(
+                    gridLine.line,
+                    sceneProjection(gridLine.start),
+                    sceneProjection(gridLine.end)
+                );
+            });
+            var activeOrigin = mode === '2d' ? {x: -1, y: -1, z: 0} : axisOrigin;
+            var origin = sceneProjection(activeOrigin);
+            axes.forEach(function (axis) {
+                var endpointDefinition = mode === '2d'
+                    ? [
+                        {x: 1.08, y: -1, z: 0},
+                        {x: -1, y: 1.08, z: 0}
+                    ][axis.index]
+                    : axis.end;
+                var isVisible = mode === '3d' || axis.index < 2;
+                axis.line.hidden = !isVisible;
+                axis.label.hidden = !isVisible;
+                if (!isVisible) return;
+                var endpoint = sceneProjection(endpointDefinition);
+                setLine(axis.line, origin, endpoint);
+                var xOffset = axis.index === 0 ? 7 : axis.index === 2 ? -5 : 0;
+                var yOffset = axis.index === 1 ? -8 : 15;
+                axis.label.setAttribute('x', clamp(endpoint.x + xOffset, 44, width - 44));
+                axis.label.setAttribute('y', clamp(endpoint.y + yOffset, 18, height - 12));
+            });
+
+            var projectedPoints = scenePoints.map(function (scenePoint) {
+                return {
+                    scenePoint: scenePoint,
+                    projected: sceneProjection(
+                        mode === '2d' ? scenePoint.coordinates2d : scenePoint.coordinates3d
+                    )
+                };
+            }).sort(function (left, right) {
+                return left.projected.z - right.projected.z;
+            });
+
+            projectedPoints.forEach(function (item) {
+                var point = item.scenePoint.point;
+                var projected = item.projected;
+                var depthRatio = mode === '2d' ? 0.72 : clamp((projected.z + 1.4) / 2.8, 0, 1);
+                var baseRadius = point.rank <= 5 ? 5.8 : 4.2;
+                item.scenePoint.circle.setAttribute('cx', projected.x);
+                item.scenePoint.circle.setAttribute('cy', projected.y);
+                item.scenePoint.circle.setAttribute('r', baseRadius * projected.perspective * (0.82 + depthRatio * 0.32));
+                item.scenePoint.circle.setAttribute('opacity', mode === '2d' ? 0.78 : 0.48 + depthRatio * 0.43);
+                pointsGroup.appendChild(item.scenePoint.circle);
+            });
+        }
+
+        scenePoints.forEach(function (scenePoint) {
+            var circle = scenePoint.circle;
+            var point = scenePoint.point;
             circle.addEventListener('mousemove', function (event) {
                 showTooltip(point, event.clientX, event.clientY);
             });
@@ -170,18 +321,14 @@
                 tooltip.hidden = true;
             });
             circle.addEventListener('focus', function () {
-                var bounds = container.getBoundingClientRect();
-                showTooltip(
-                    point,
-                    bounds.left + (cx / width) * bounds.width,
-                    bounds.top + (cy / height) * bounds.height
-                );
+                var bounds = circle.getBoundingClientRect();
+                showTooltip(point, bounds.left + bounds.width / 2, bounds.top + bounds.height / 2);
             });
             circle.addEventListener('blur', function () {
                 tooltip.hidden = true;
             });
             circle.addEventListener('click', function () {
-                window.location.assign('/model/vision/' + point.id);
+                if (!suppressClick) window.location.assign('/model/vision/' + point.id);
             });
             circle.addEventListener('keydown', function (event) {
                 if (event.key === 'Enter' || event.key === ' ') {
@@ -189,8 +336,100 @@
                     window.location.assign('/model/vision/' + point.id);
                 }
             });
-            svg.appendChild(circle);
         });
+
+        svg.addEventListener('pointerdown', function (event) {
+            if (mode !== '3d' || event.button !== 0) return;
+            dragging = true;
+            dragMoved = false;
+            lastPointer = {x: event.clientX, y: event.clientY};
+            svg.setPointerCapture(event.pointerId);
+            svg.classList.add('is-dragging');
+        });
+        svg.addEventListener('pointermove', function (event) {
+            if (!dragging) return;
+            var deltaX = event.clientX - lastPointer.x;
+            var deltaY = event.clientY - lastPointer.y;
+            if (Math.abs(deltaX) + Math.abs(deltaY) > 1) dragMoved = true;
+            camera.yaw += deltaX * 0.008;
+            camera.pitch = clamp(camera.pitch - deltaY * 0.008, -1.12, 1.12);
+            lastPointer = {x: event.clientX, y: event.clientY};
+            renderScene();
+        });
+        function finishDrag(event) {
+            if (!dragging) return;
+            dragging = false;
+            suppressClick = dragMoved;
+            svg.classList.remove('is-dragging');
+            if (svg.hasPointerCapture(event.pointerId)) svg.releasePointerCapture(event.pointerId);
+            window.setTimeout(function () { suppressClick = false; }, 0);
+        }
+        svg.addEventListener('pointerup', finishDrag);
+        svg.addEventListener('pointercancel', finishDrag);
+        svg.addEventListener('keydown', function (event) {
+            if (mode !== '3d') return;
+            var handled = true;
+            if (event.key === 'ArrowLeft') camera.yaw -= 0.12;
+            else if (event.key === 'ArrowRight') camera.yaw += 0.12;
+            else if (event.key === 'ArrowUp') camera.pitch = clamp(camera.pitch + 0.12, -1.12, 1.12);
+            else if (event.key === 'ArrowDown') camera.pitch = clamp(camera.pitch - 0.12, -1.12, 1.12);
+            else if (event.key === 'Home') {
+                camera.yaw = DEFAULT_CAMERA.yaw;
+                camera.pitch = DEFAULT_CAMERA.pitch;
+            } else handled = false;
+            if (handled) {
+                event.preventDefault();
+                renderScene();
+            }
+        });
+
+        var resetButton = document.getElementById('landing-space-reset');
+        if (resetButton) {
+            resetButton.addEventListener('click', function () {
+                camera.yaw = DEFAULT_CAMERA.yaw;
+                camera.pitch = DEFAULT_CAMERA.pitch;
+                renderScene();
+                svg.focus();
+            });
+        }
+
+        var title = document.getElementById('landing-space-title');
+        var hint = document.getElementById('landing-space-hint');
+        var method = document.getElementById('landing-space-method');
+        var modeButtons = document.querySelectorAll('.landing-space-toggle button[data-space-mode]');
+
+        function setMode(nextMode) {
+            mode = nextMode === '3d' ? '3d' : '2d';
+            container.dataset.spaceMode = mode;
+            modeButtons.forEach(function (button) {
+                button.setAttribute('aria-pressed', button.dataset.spaceMode === mode ? 'true' : 'false');
+            });
+            if (title) title.textContent = 'The ' + mode.toUpperCase() + ' benchmark space';
+            if (hint) {
+                hint.innerHTML = mode === '3d'
+                    ? '<i class="fa-regular fa-hand-pointer" aria-hidden="true"></i> Drag to rotate'
+                    : 'PC1 &times; PC2';
+            }
+            if (resetButton) resetButton.hidden = mode !== '3d';
+            if (method) {
+                method.textContent = mode === '3d'
+                    ? 'A three-component preview of the highest-ranked public models with complete scores across the five displayed branches. Drag to rotate; hover or focus a point for model details.'
+                    : 'A two-component preview of the highest-ranked public models with complete scores across the five displayed branches. Hover or focus a point for model details.';
+            }
+            svg.setAttribute('aria-label', mode === '3d'
+                ? 'Interactive three-dimensional principal component map. Drag or use the arrow keys to rotate. Select a point to open its model page.'
+                : 'Two-dimensional principal component map. Select a point to open its model page.');
+            svg.classList.toggle('is-3d', mode === '3d');
+            renderScene();
+        }
+
+        modeButtons.forEach(function (button) {
+            button.addEventListener('click', function () {
+                setMode(button.dataset.spaceMode);
+            });
+        });
+
+        setMode(mode);
     }
 
     if (document.readyState === 'loading') {

--- a/static/benchmarks/js/landing-dashboard.js
+++ b/static/benchmarks/js/landing-dashboard.js
@@ -92,6 +92,10 @@
         line.setAttribute('y2', end.y);
     }
 
+    function setSvgElementVisible(element, visible) {
+        element.style.display = visible ? '' : 'none';
+    }
+
     function renderBenchmarkSpace() {
         var container = document.getElementById('landing-benchmark-space');
         var dataElement = document.getElementById('landing-benchmark-space-data');
@@ -237,13 +241,13 @@
 
         function renderTwoDimensionalScene() {
             gridLines3d.forEach(function (gridLine) {
-                gridLine.line.hidden = true;
+                setSvgElementVisible(gridLine.line, false);
             });
             var xAxisY = height - twoDimensionalMargin.bottom;
             axes.forEach(function (axis) {
                 var isVisible = axis.index < 2;
-                axis.line.hidden = !isVisible;
-                axis.label.hidden = !isVisible;
+                setSvgElementVisible(axis.line, isVisible);
+                setSvgElementVisible(axis.label, isVisible);
                 if (!isVisible) return;
                 axis.label.removeAttribute('transform');
                 if (axis.index === 0) {
@@ -290,7 +294,7 @@
 
         function renderThreeDimensionalScene() {
             gridLines3d.forEach(function (gridLine) {
-                gridLine.line.hidden = false;
+                setSvgElementVisible(gridLine.line, true);
                 setLine(
                     gridLine.line,
                     projectPoint(gridLine.start, camera, dimensions),
@@ -299,8 +303,8 @@
             });
             var origin = projectPoint(axisOrigin, camera, dimensions);
             axes.forEach(function (axis) {
-                axis.line.hidden = false;
-                axis.label.hidden = false;
+                setSvgElementVisible(axis.line, true);
+                setSvgElementVisible(axis.label, true);
                 axis.label.removeAttribute('transform');
                 axis.label.textContent = axisDefinitions[axis.index].label;
                 var endpoint = projectPoint(axis.end, camera, dimensions);


### PR DESCRIPTION
## Summary

- redesign the homepage around recent platform updates and public model submissions
- add a full-width two-dimensional PCA preview of high-level vision benchmark scores beside a live leaderboard preview
- let visitors toggle the PCA preview between the default 2D view and an interactive 3D view
- add benchmark and model comparison entry points plus local usage and community calls to action
- use contributor initials as an avatar-ready placeholder because the current user schema has no profile-image field

<img width="1716" height="3168" alt="image" src="https://github.com/user-attachments/assets/d69a9a30-22ad-45ac-8cc8-86de93d04bc9" />

## Implementation

- derive three PCA components from V1, V2, V4, IT, and behavioral aggregate scores in the existing materialized model context
- keep the original full-width 2D composition as the initial view and reuse the same data for the opt-in 3D projection
- cache landing dashboard data for 15 minutes and fail gracefully when the database is unavailable
- render the PCA with responsive SVG and omit Plotly, D3, Chart.js, and jStat from the homepage
- require no database or schema changes

## Validation

- landing-page and homepage tests
- complete Sass bundle compilation
- JavaScript syntax validation
- compressed asset build
- live local homepage and static-asset checks
- measured landing-data preparation at about 0.84 seconds cold and 0.002 seconds cached

## Follow-up

- #551 is stacked on this PR and applies the landing-page aesthetic to the shared application shell